### PR TITLE
small user payload to upload to wigle on demand

### DIFF
--- a/library/user/general/wigle_upload/payload.sh
+++ b/library/user/general/wigle_upload/payload.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Title: Wigle Upload
+# Author: marcdel
+# Description: Upload captured data to Wigle.net
+# Version: 1.0
+
+LOG "Uploading $(ls -1 /root/loot/wigle | wc -l) files to wigle.net"
+WIGLE_UPLOAD --archive /root/loot/wigle/*.csv


### PR DESCRIPTION
this is currently blocked by a bug in WIGLE_UPLOAD. i made a bug report through the [form](https://shop.hak5.org/pages/pager-setup) but tl;dr: for anyone wanting to get this working now, WIGLE_UPLOAD tries read apiname, but WIGLE_LOGIN writes authname.

Modify this line in WIGLE_UPLOAD to use authname instead of apiname and it'll work
```
__apiname=$(PAYLOAD_GET_CONFIG wigle apiname)
```