### PR TITLE
Payloads for Installation and Management of Tailscale Services

### DIFF
--- a/library/user/remote_access/tailscale_configure/README.md
+++ b/library/user/remote_access/tailscale_configure/README.md
@@ -1,0 +1,211 @@
+# Tailscale Payloads for WiFi Pineapple Pager
+
+A complete suite of payloads for managing Tailscale on the WiFi Pineapple Pager.
+
+## Available Payloads
+
+### 1. Tailscale Installer (`tailscale_installer/`)
+**Purpose:** Install Tailscale binaries and init script
+
+**Features:**
+- Automatically detects and downloads latest Tailscale for mipsle architecture
+- Installs binaries to /usr/sbin
+- Creates init.d service script
+- Creates configuration directories
+
+**When to use:** First-time setup or reinstallation
+
+**Important:** After installation, you MUST run **Tailscale Configure** to complete setup.
+
+---
+
+### 2. Tailscale Configure (`tailscale_configure/`)
+**Purpose:** Configure Tailscale after installation
+
+**Features:**
+- Configure auto-start preference
+- Interactive authentication via URL
+- Start Tailscale service
+- Connect to Tailscale network
+
+**When to use:**
+- Immediately after running Tailscale Installer
+- To reconfigure settings
+
+**Note:** Interactive authentication is recommended as it doesn't require typing long keys on the device.
+
+---
+
+### 3. Tailscale Status (`tailscale_status/`)
+**Purpose:** Check current Tailscale connection status
+
+**Features:**
+- Shows connection state (Connected/Stopped/Needs Login)
+- Displays Tailscale IP address
+- Shows connected devices
+- Logs full status information
+
+**When to use:** Check if Tailscale is running and connected
+
+---
+
+### 4. Tailscale Connect (`tailscale_connect/`)
+**Purpose:** Connect to Tailscale network
+
+**Features:**
+- Starts tailscaled daemon if needed
+- Interactive authentication via URL if needed
+- Displays authentication URL when required
+- Shows assigned Tailscale IP on success
+
+**When to use:**
+- After reboot to reconnect
+- After disconnecting
+- To re-authenticate
+
+---
+
+### 5. Tailscale Disconnect (`tailscale_disconnect/`)
+**Purpose:** Disconnect from Tailscale network
+
+**Features:**
+- Gracefully disconnects from network
+- Keeps Tailscale installed
+- Confirmation dialog to prevent accidents
+
+**When to use:**
+- Temporarily disconnect without uninstalling
+- Conserve battery/bandwidth
+- Switch networks
+
+---
+
+### 6. Tailscale Uninstaller (`tailscale_uninstaller/`)
+**Purpose:** Completely remove Tailscale from device
+
+**Features:**
+- Stops and disables service
+- Removes all binaries
+- Deletes configuration and state
+- Double confirmation to prevent accidents
+
+**When to use:** Complete removal of Tailscale
+
+---
+
+## Quick Start Guide
+
+### First Time Setup
+1. Run **Tailscale Installer**
+2. Wait for installation to complete
+3. Run **Tailscale Configure**
+4. Choose auto-start preference
+5. Visit authentication URL on another device
+6. Wait for authentication to complete (automatic)
+7. Note your Tailscale IP (displayed on screen)
+8. Press any button to exit
+
+
+### Removal
+1. Run **Tailscale Uninstaller**
+2. Confirm twice
+3. All files removed
+
+### Scenario: Device Rebooted
+```
+1. Run: Tailscale Status (check if auto-start worked)
+2. If not connected: Run Tailscale Connect
+```
+
+### Scenario: Need to Re-authenticate
+```
+1. Run: Tailscale Connect
+2. Visit URL shown in logs (if authentication required)
+3. Approve device
+```
+
+### Scenario: Switching Tailscale Accounts
+```
+1. Run: Tailscale Disconnect
+2. Run: Tailscale Connect
+3. Authenticate with new account
+```
+
+### Scenario: Complete Removal
+```
+1. Run: Tailscale Disconnect (optional)
+2. Run: Tailscale Uninstaller
+3. Confirm removal
+```
+
+## File Locations
+
+- **Binaries:** `/usr/sbin/tailscale`, `/usr/sbin/tailscaled`
+- **Init Script:** `/etc/init.d/tailscaled`
+- **Configuration:** `/etc/tailscale/`
+- **State:** `/var/lib/tailscale/`
+- **Runtime:** `/var/run/tailscale/`
+
+## Manual Commands (SSH)
+
+Tailscale CLI Reference:
+https://tailscale.com/kb/1080/cli
+
+If you prefer SSH access:
+
+```bash
+# Check status
+tailscale status
+
+# Get IP
+tailscale ip -4
+
+# Connect
+tailscale up
+
+# Disconnect
+tailscale down
+
+# Service control
+/etc/init.d/tailscaled start
+/etc/init.d/tailscaled stop
+/etc/init.d/tailscaled restart
+/etc/init.d/tailscaled enable   # Auto-start
+/etc/init.d/tailscaled disable  # No auto-start
+```
+
+## Troubleshooting
+
+### Payload Not Showing in UI
+- Ensure files are in `/root/payloads/user/tailscale/`
+- Check that `payload.sh` is executable: `chmod +x payload.sh`
+- Verify file is named `payload.sh` or `payload`
+
+### Connection Fails
+- Run **Tailscale Status** to check daemon
+- Verify internet connectivity
+- Check logs for error messages
+- Try re-authentication
+
+### Auth URL Not Working
+- Ensure URL is complete (check logs)
+- Try copying full URL manually
+- Try running Tailscale Configure again
+
+### Service Won't Start
+- Check if binaries exist: `ls -la /usr/sbin/tailscale*`
+- Verify init script: `ls -la /etc/init.d/tailscaled`
+- Check logs: `logread | grep tailscale`
+
+## Security Notes
+
+- Configure ACLs in Tailscale admin panel to restrict access
+- Regularly review connected devices
+- Disable auto-start if device may be captured
+- Remove device from Tailscale admin if compromised
+
+## Support
+
+- Tailscale Documentation: https://tailscale.com/kb/
+- Tailscale Admin Console: https://login.tailscale.com/admin/
+

--- a/library/user/remote_access/tailscale_configure/payload.sh
+++ b/library/user/remote_access/tailscale_configure/payload.sh
@@ -1,0 +1,315 @@
+#!/bin/bash
+# Title: Tailscale Configuration
+# Description: Configure Tailscale after installation
+# Author: JAKONL
+# Version: 1.0
+
+LOG "=== Tailscale Configuration ==="
+
+# ============================================
+# CONFIGURATION
+# ============================================
+
+INSTALL_DIR="/usr/sbin"
+INIT_SCRIPT="/etc/init.d/tailscaled"
+CONFIG_DIR="/etc/tailscale"
+CONFIG_FILE="$CONFIG_DIR/config"
+STATE_DIR="/var/lib/tailscale"
+
+# ============================================
+# HELPER FUNCTIONS
+# ============================================
+
+save_config() {
+    local auto_start="$1"
+
+    cat > "$CONFIG_FILE" << EOF
+# Tailscale Configuration
+AUTO_START=$auto_start
+CONFIGURED_DATE=$(date)
+EOF
+
+    LOG "Configuration saved"
+}
+
+load_config() {
+    if [ -f "$CONFIG_FILE" ]; then
+        source "$CONFIG_FILE"
+        return 0
+    fi
+    return 1
+}
+
+start_tailscaled() {
+    LOG "Starting tailscaled daemon..."
+    
+    # Create socket directory
+    mkdir -p /var/run/tailscale
+    
+    # Start the daemon
+    if ! "$INIT_SCRIPT" start; then
+        ERROR_DIALOG "Failed to start tailscaled"
+        LOG "ERROR: Could not start tailscaled service"
+        return 1
+    fi
+    
+    # Wait for daemon to be ready
+    sleep 3
+    
+    LOG "Tailscaled started successfully"
+    return 0
+}
+
+authenticate_interactive() {
+    LOG "Starting interactive authentication..."
+
+    # Create a temporary file for output
+    local tmp_output="/tmp/tailscale_auth_output.txt"
+
+    # Run tailscale login in background and capture output
+    LOG "Running: tailscale login"
+    "$INSTALL_DIR/tailscale" login > "$tmp_output" 2>&1 &
+    local tailscale_pid=$!
+
+    LOG "Waiting for authentication URL..."
+
+    # Wait for the auth URL to appear in output (no spinner - quick operation)
+    local auth_url=""
+    local max_wait=30
+    local waited=0
+
+    while [ $waited -lt $max_wait ]; do
+        if [ -f "$tmp_output" ]; then
+            # Check if already authenticated
+            if grep -q "Success" "$tmp_output" 2>/dev/null; then
+                LOG "Device is already authenticated"
+                rm -f "$tmp_output"
+                return 0
+            fi
+
+            # Look for auth URL
+            auth_url=$(grep -o 'https://login.tailscale.com/a/[a-zA-Z0-9]*' "$tmp_output" 2>/dev/null | head -n 1)
+
+            if [ -n "$auth_url" ]; then
+                break
+            fi
+        fi
+
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    if [ -z "$auth_url" ]; then
+        # Check if process failed
+        if ! kill -0 $tailscale_pid 2>/dev/null; then
+            ERROR_DIALOG "Authentication failed"
+            LOG "ERROR: tailscale login process exited unexpectedly"
+            if [ -f "$tmp_output" ]; then
+                LOG "Output:"
+                cat "$tmp_output" 2>&1 | while read line; do LOG "$line"; done
+                rm -f "$tmp_output"
+            fi
+            return 1
+        fi
+
+        ERROR_DIALOG "Could not get auth URL"
+        LOG "ERROR: No authentication URL found after ${max_wait}s"
+        if [ -f "$tmp_output" ]; then
+            LOG "Output:"
+            cat "$tmp_output" 2>&1 | while read line; do LOG "$line"; done
+        fi
+        kill $tailscale_pid 2>/dev/null
+        rm -f "$tmp_output"
+        return 1
+    fi
+
+    # Display the authentication URL clearly
+    LOG ""
+    LOG "=========================================="
+    LOG "AUTHENTICATION REQUIRED"
+    LOG "=========================================="
+    LOG ""
+    LOG "Visit this URL on another device:"
+    LOG ""
+    LOG "  $auth_url"
+    LOG ""
+    LOG "=========================================="
+    LOG ""
+    LOG "Waiting for you to complete authentication..."
+    LOG "Do NOT press any buttons - authentication will complete automatically"
+    LOG ""
+
+    max_wait=300  # 5 minutes - give user plenty of time
+    waited=0
+    local auth_success=false
+
+    while [ $waited -lt $max_wait ]; do
+        # Check if tailscale login process completed
+        if ! kill -0 $tailscale_pid 2>/dev/null; then
+            # Process finished, check if successful
+            if "$INSTALL_DIR/tailscale" status >/dev/null 2>&1; then
+                auth_success=true
+                break
+            else
+                # Process ended but not authenticated - error
+                ERROR_DIALOG "Authentication failed"
+                LOG "ERROR: tailscale login completed but device not authenticated"
+                if [ -f "$tmp_output" ]; then
+                    LOG "Output:"
+                    cat "$tmp_output" 2>&1 | while read line; do LOG "$line"; done
+                fi
+                rm -f "$tmp_output"
+                return 1
+            fi
+        fi
+
+        sleep 5
+        waited=$((waited + 5))
+    done
+
+    if [ "$auth_success" = true ]; then
+        LOG "Authentication completed successfully"
+        rm -f "$tmp_output"
+
+        # Now bring up the Tailscale connection
+        LOG "Starting Tailscale connection..."
+        if ! "$INSTALL_DIR/tailscale" up 2>&1 | while read line; do LOG "$line"; done; then
+            ERROR_DIALOG "Failed to start Tailscale"
+            LOG red "ERROR: tailscale up failed after authentication"
+            return 1
+        fi
+
+        LOG green "Tailscale connection established"
+        return 0
+    else
+        ERROR_DIALOG "Authentication timeout (5 min)"
+        LOG "ERROR: Authentication timed out after ${max_wait}s"
+        LOG "Please complete authentication at: $auth_url"
+
+        # Kill the background process
+        kill $tailscale_pid 2>/dev/null
+        rm -f "$tmp_output"
+        return 1
+    fi
+}
+
+
+
+show_status() {
+    LOG "Getting Tailscale status..."
+
+    local status=$("$INSTALL_DIR/tailscale" status 2>&1)
+    local ip=$("$INSTALL_DIR/tailscale" ip -4 2>/dev/null | head -n 1)
+
+    if [ -n "$ip" ]; then
+        LOG ""
+        LOG "=========================================="
+        LOG "✓ AUTHENTICATION SUCCESSFUL!"
+        LOG "=========================================="
+        LOG ""
+        LOG "Your Tailscale IP Address: $ip"
+        LOG ""
+        LOG "Full status:"
+        LOG "$status"
+        LOG ""
+
+        # Show IP once in PROMPT only - user must acknowledge to exit
+        PROMPT "Tailscale IP: $ip - Press OK to exit"
+    else
+        LOG "Status: $status"
+        PROMPT "Tailscale connected - Press OK to exit"
+    fi
+}
+
+# ============================================
+# MAIN CONFIGURATION
+# ============================================
+
+main_configure() {
+    LOG "=== Tailscale Configuration Started ==="
+
+    # Check if already configured
+    if load_config; then
+        LOG "Tailscale is already configured"
+
+        # Try to get current IP address
+        local current_ip=$("$INSTALL_DIR/tailscale" ip -4 2>/dev/null | head -n 1)
+
+        if [ -n "$current_ip" ]; then
+            LOG "Current Tailscale IP: $current_ip"
+            LOG ""
+
+            # Show current IP and ask if they want to reconfigure
+            resp=$(CONFIRMATION_DIALOG "Current IP: $current_ip - Reconfigure?")
+        else
+            LOG "Tailscale configured but no IP found (may not be connected)"
+            LOG ""
+
+            # No IP available, just ask about reconfiguration
+            resp=$(CONFIRMATION_DIALOG "Reconfigure Tailscale?")
+        fi
+
+        case $? in
+            $DUCKYSCRIPT_REJECTED|$DUCKYSCRIPT_ERROR)
+                LOG "Configuration cancelled"
+                exit 0
+                ;;
+        esac
+
+        case "$resp" in
+            $DUCKYSCRIPT_USER_DENIED)
+                LOG "User chose not to reconfigure"
+
+                # If we have an IP, show it before exiting
+                if [ -n "$current_ip" ]; then
+                    PROMPT "Current IP: $current_ip - Press OK to exit"
+                fi
+
+                exit 0
+                ;;
+        esac
+
+        LOG "User chose to reconfigure Tailscale"
+    fi
+    
+    # Ask about auto-start
+    resp=$(CONFIRMATION_DIALOG "Enable auto-start at boot?")
+    local auto_start="no"
+    case "$resp" in
+        $DUCKYSCRIPT_USER_CONFIRMED)
+            auto_start="yes"
+            "$INIT_SCRIPT" enable
+            LOG "Auto-start enabled"
+            ;;
+        *)
+            "$INIT_SCRIPT" disable
+            LOG "Auto-start disabled"
+            ;;
+    esac
+    
+    # Start the daemon
+    if ! start_tailscaled; then
+        exit 1
+    fi
+
+    # Perform interactive authentication
+    LOG ""
+    LOG green "Starting authentication..."
+    LOG ""
+
+    if ! authenticate_interactive; then
+        exit 1
+    fi
+
+    # Save configuration
+    save_config "$auto_start"
+
+    # Show status (includes user prompt to exit)
+    show_status
+
+    LOG "=== Configuration Complete ==="
+}
+
+# Execute configuration
+main_configure
+

--- a/library/user/remote_access/tailscale_connect/payload.sh
+++ b/library/user/remote_access/tailscale_connect/payload.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Title: Tailscale Connect
+# Description: Connect to Tailscale network
+# Author: JAKONL
+# Version: 1.0
+
+LOG "=== Tailscale Connect ==="
+
+# ============================================
+# CONFIGURATION
+# ============================================
+
+INSTALL_DIR="/usr/sbin"
+TAILSCALE="$INSTALL_DIR/tailscale"
+TAILSCALED="$INSTALL_DIR/tailscaled"
+INIT_SCRIPT="/etc/init.d/tailscaled"
+
+# ============================================
+# MAIN
+# ============================================
+
+if [ ! -f "$TAILSCALE" ]; then
+    ERROR_DIALOG "Tailscale not installed"
+    LOG red "ERROR: Tailscale is not installed"
+    exit 1
+fi
+
+LOG "Starting Tailscale connection..."
+
+# Start tailscaled if not running
+if ! pgrep tailscaled > /dev/null; then
+    LOG "Starting tailscaled daemon..."
+    if [ -f "$INIT_SCRIPT" ]; then
+        "$INIT_SCRIPT" start
+    else
+        "$TAILSCALED" --state=/var/lib/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock &
+    fi
+    sleep 3
+fi
+
+LOG "Connecting to Tailscale network..."
+
+# Connect using tailscale up
+spinner_id=$(START_SPINNER "Connecting")
+output=$("$TAILSCALE" up 2>&1)
+result=$?
+
+# Extract auth URL if present
+auth_url=$(echo "$output" | grep -o 'https://login.tailscale.com/a/[a-zA-Z0-9]*')
+
+if [ -n "$auth_url" ]; then
+    STOP_SPINNER $spinner_id
+    LOG "Authentication required"
+    LOG "Auth URL: $auth_url"
+
+    # Show shortened URL
+    url_code=$(echo "$auth_url" | sed 's|https://login.tailscale.com/a/||')
+    ALERT "Auth needed - check logs"
+    PROMPT "Code: $url_code - Press button"
+
+    # Wait for auth
+    spinner_id=$(START_SPINNER "Waiting for auth")
+    sleep 30
+fi
+
+STOP_SPINNER $spinner_id
+
+# Check result
+if [ $result -eq 0 ] || echo "$output" | grep -q "Success"; then
+    # Get IP
+    ip=$("$TAILSCALE" ip -4 2>&1 | head -n 1)
+    ALERT "Connected: $ip"
+    LOG green "Successfully connected to Tailscale"
+    LOG "Tailscale IP: $ip"
+else
+    ERROR_DIALOG "Connection failed"
+    LOG red "ERROR: Failed to connect"
+    LOG "$output"
+    exit 1
+fi
+
+LOG "=== Connection Complete ==="
+

--- a/library/user/remote_access/tailscale_disconnect/payload.sh
+++ b/library/user/remote_access/tailscale_disconnect/payload.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# Title: Tailscale Disconnect
+# Description: Disconnect from Tailscale network
+# Author: JAKONL
+# Version: 1.0
+
+LOG "=== Tailscale Disconnect ==="
+
+# ============================================
+# CONFIGURATION
+# ============================================
+
+INSTALL_DIR="/usr/sbin"
+TAILSCALE="$INSTALL_DIR/tailscale"
+
+# ============================================
+# MAIN
+# ============================================
+
+if [ ! -f "$TAILSCALE" ]; then
+    ERROR_DIALOG "Tailscale not installed"
+    LOG red "ERROR: Tailscale is not installed"
+    exit 1
+fi
+
+# Confirm disconnection
+resp=$(CONFIRMATION_DIALOG "Disconnect from Tailscale?")
+case $? in
+    $DUCKYSCRIPT_REJECTED|$DUCKYSCRIPT_ERROR)
+        LOG "Disconnect cancelled"
+        exit 0
+        ;;
+esac
+
+case "$resp" in
+    $DUCKYSCRIPT_USER_CONFIRMED)
+        LOG "Disconnecting from Tailscale network..."
+        
+        spinner_id=$(START_SPINNER "Disconnecting")
+        
+        # Disconnect
+        output=$("$TAILSCALE" down 2>&1)
+        result=$?
+        
+        STOP_SPINNER $spinner_id
+        
+        if [ $result -eq 0 ]; then
+            ALERT "Disconnected"
+            LOG green "Successfully disconnected from Tailscale"
+        else
+            ERROR_DIALOG "Disconnect failed"
+            LOG red "ERROR: Failed to disconnect"
+            LOG "$output"
+            exit 1
+        fi
+        ;;
+    $DUCKYSCRIPT_USER_DENIED)
+        LOG "User cancelled disconnect"
+        ALERT "Disconnect cancelled"
+        exit 0
+        ;;
+    *)
+        LOG "ERROR: Unknown response: $resp"
+        ERROR_DIALOG "Unknown response"
+        exit 1
+        ;;
+esac
+
+LOG "=== Disconnect Complete ==="
+

--- a/library/user/remote_access/tailscale_installer/DUCKYSCRIPT_REFERENCE.md
+++ b/library/user/remote_access/tailscale_installer/DUCKYSCRIPT_REFERENCE.md
@@ -1,0 +1,231 @@
+# DuckyScript Commands Used in Tailscale Installer
+
+This document lists all DuckyScript™ commands used in the Tailscale installer payload.
+
+## Commands Used
+
+### LOG
+Writes messages to the payload log (visible in Pager UI).
+
+```bash
+LOG "Message text"
+LOG red "Error message"
+LOG green "Success message"
+LOG blue "Info message"
+```
+
+**Usage in payload:**
+- Installation progress updates
+- Configuration steps
+- Error messages
+- Status information
+
+### ALERT
+Displays a popup alert message on the Pager screen.
+
+```bash
+ALERT "Message to display"
+```
+
+**Usage in payload:**
+- Installation complete notifications
+- Authentication success/failure
+- Important status updates
+- User-facing confirmations
+
+### ERROR_DIALOG
+Displays an error dialog on the Pager screen.
+
+```bash
+ERROR_DIALOG "Error message"
+```
+
+**Usage in payload:**
+- Download failures
+- Installation errors
+- Authentication failures
+- Configuration errors
+
+### CONFIRMATION_DIALOG
+Prompts user with Yes/No question.
+
+```bash
+resp=$(CONFIRMATION_DIALOG "Question?")
+case $? in
+    $DUCKYSCRIPT_REJECTED)
+        # Dialog was rejected/cancelled
+        ;;
+    $DUCKYSCRIPT_ERROR)
+        # An error occurred
+        ;;
+esac
+
+case "$resp" in
+    $DUCKYSCRIPT_USER_CONFIRMED)
+        # User selected Yes
+        ;;
+    $DUCKYSCRIPT_USER_DENIED)
+        # User selected No
+        ;;
+esac
+```
+
+**Usage in payload:**
+- Reinstall confirmation
+- Auto-start preference
+- Authentication method selection
+- Uninstall confirmation
+
+### TEXT_PICKER
+Prompts user to enter text input.
+
+```bash
+resp=$(TEXT_PICKER "Prompt text" "default_value")
+case $? in
+    $DUCKYSCRIPT_CANCELLED)
+        # User cancelled
+        ;;
+    $DUCKYSCRIPT_REJECTED)
+        # Dialog rejected
+        ;;
+    $DUCKYSCRIPT_ERROR)
+        # An error occurred
+        ;;
+esac
+
+# $resp contains the entered text
+```
+
+**Usage in payload:**
+- Auth key entry
+- Configuration values
+
+### START_SPINNER / STOP_SPINNER
+Shows a loading spinner with message.
+
+```bash
+spinner_id=$(START_SPINNER "Loading message")
+# Do work...
+STOP_SPINNER $spinner_id
+```
+
+**Usage in payload:**
+- Download progress
+- Installation progress
+- Authentication waiting
+- Network operations
+
+### PROMPT
+Displays a message and waits for button press.
+
+```bash
+PROMPT "Press any button to continue"
+```
+
+**Usage in payload:**
+- Displaying authentication URL
+- Pausing for user to read information
+
+## Response Code Constants
+
+All DuckyScript input commands use these standard response codes:
+
+- `$DUCKYSCRIPT_CANCELLED` - User cancelled the operation
+- `$DUCKYSCRIPT_REJECTED` - Dialog was rejected
+- `$DUCKYSCRIPT_ERROR` - An error occurred
+- `$DUCKYSCRIPT_USER_CONFIRMED` - User selected Yes (CONFIRMATION_DIALOG)
+- `$DUCKYSCRIPT_USER_DENIED` - User selected No (CONFIRMATION_DIALOG)
+
+## Best Practices
+
+### Always Check Return Codes
+
+```bash
+resp=$(CONFIRMATION_DIALOG "Continue?")
+case $? in
+    $DUCKYSCRIPT_REJECTED|$DUCKYSCRIPT_ERROR)
+        LOG "Operation cancelled"
+        exit 1
+        ;;
+esac
+```
+
+### Handle All Response Cases
+
+```bash
+case "$resp" in
+    $DUCKYSCRIPT_USER_CONFIRMED)
+        # Handle Yes
+        ;;
+    $DUCKYSCRIPT_USER_DENIED)
+        # Handle No
+        ;;
+    *)
+        # Handle unexpected response
+        LOG "ERROR: Unknown response: $resp"
+        ;;
+esac
+```
+
+### Provide User Feedback
+
+Always use LOG and ALERT to keep users informed:
+
+```bash
+LOG "Starting operation..."
+spinner_id=$(START_SPINNER "Processing")
+# Do work
+STOP_SPINNER $spinner_id
+ALERT "Operation complete!"
+LOG "Operation completed successfully"
+```
+
+### Validate Input
+
+```bash
+value=$(TEXT_PICKER "Enter value:" "")
+case $? in
+    $DUCKYSCRIPT_CANCELLED|$DUCKYSCRIPT_REJECTED|$DUCKYSCRIPT_ERROR)
+        LOG "Input cancelled"
+        exit 1
+        ;;
+esac
+
+if [ -z "$value" ]; then
+    ERROR_DIALOG "Value cannot be empty"
+    LOG "ERROR: Empty value provided"
+    exit 1
+fi
+```
+
+## Command Flow in Tailscale Installer
+
+### payload.sh
+1. `LOG` - Installation start
+2. `CONFIRMATION_DIALOG` - Check if reinstall needed
+3. `START_SPINNER` - Download progress
+4. `STOP_SPINNER` - Download complete
+5. `ALERT` - Installation success
+
+### configure.sh
+1. `LOG` - Configuration start
+2. `CONFIRMATION_DIALOG` - Reconfigure check
+3. `CONFIRMATION_DIALOG` - Auto-start preference
+4. `CONFIRMATION_DIALOG` - Auth method selection
+5. `TEXT_PICKER` - Auth key entry (if selected)
+6. `START_SPINNER` - Authentication progress
+7. `PROMPT` - Display auth URL
+8. `ALERT` - Configuration complete
+
+### manage.sh
+1. `LOG` - Management operation start
+2. `CONFIRMATION_DIALOG` - Operation confirmation
+3. `ALERT` - Operation result
+4. `ERROR_DIALOG` - Error conditions
+
+## Additional Resources
+
+- Full DuckyScript documentation: See payloads/README.md
+- Example payloads: payloads/library/user/examples/
+- Hak5 Payload Studio: https://payloadstudio.hak5.org
+

--- a/library/user/remote_access/tailscale_installer/QUICKSTART.md
+++ b/library/user/remote_access/tailscale_installer/QUICKSTART.md
@@ -1,0 +1,80 @@
+# Tailscale Quick Start Guide
+
+## 12-Minute Setup
+
+### Step 1: Install
+```bash
+cd /payloads/library/user/remote_access/tailscale_installer/
+./payload.sh
+```
+
+The installer will automatically detect and install the latest stable version of Tailscale.
+
+### Step 2: Configure
+- Choose "Yes" for auto-start (recommended)
+- Note the authentication URL in the logs
+
+### Step 3: Authenticate
+- Visit the URL on your phone/laptop
+- Log in to Tailscale
+- Approve the device
+
+### Step 4: Get Your IP
+```bash
+tailscale ip -4
+```
+
+### Step 5: Connect
+```bash
+ssh root@100.x.y.z
+```
+
+## Common Commands
+
+```bash
+# Status
+./manage.sh status
+
+# Start/Stop
+./manage.sh start
+./manage.sh stop
+
+# Reconnect
+./manage.sh restart
+```
+
+## Troubleshooting
+
+### Can't connect?
+```bash
+# Check status
+tailscale status
+
+# Restart service
+/etc/init.d/tailscaled restart
+
+# Reconnect
+tailscale up
+```
+
+### Forgot your IP?
+```bash
+tailscale ip -4
+```
+
+### Need to re-authenticate?
+```bash
+./manage.sh reauth
+```
+
+## Uninstall
+```bash
+./manage.sh uninstall
+```
+
+## Support
+
+- Full documentation: See README.md
+- Tailscale docs: https://tailscale.com/kb/
+- Admin console: https://login.tailscale.com/admin
+

--- a/library/user/remote_access/tailscale_installer/README.md
+++ b/library/user/remote_access/tailscale_installer/README.md
@@ -1,0 +1,296 @@
+# Tailscale VPN Installer for WiFi Pineapple Pager
+
+**Author:** JAKONL  
+**Version:** 1.0  
+**Category:** Remote Access  
+**Target:** WiFi Pineapple Pager
+
+## Description
+
+This payload installs and configures Tailscale VPN on the WiFi Pineapple Pager, enabling secure remote access to your device from anywhere in the world. Tailscale creates a secure mesh VPN network using WireGuard, allowing you to access your Pager even when it's behind NAT or firewalls.
+
+Perfect for:
+- Remote management during field operations
+- Secure access without port forwarding
+- Persistent connectivity across network changes
+- Multi-device coordination in red team operations
+
+## Features
+
+- ✅ **Automated Installation** - Downloads and installs latest Tailscale for MIPS architecture
+- ✅ **Latest Version Detection** - Automatically detects and installs the latest stable release
+- ✅ **Interactive Setup** - User-friendly configuration wizard
+- ✅ **Interactive Authentication** - Simple URL-based authentication
+- ✅ **Auto-Start Option** - Configure service to start at boot
+- ✅ **Management Tools** - Easy start/stop/status commands
+- ✅ **Complete Uninstaller** - Clean removal when needed
+- ✅ **Progress Indicators** - Visual feedback during installation
+- ✅ **Error Handling** - Comprehensive error checking and recovery
+
+## TODO
+- [ ] Add exit node selection payload
+
+## What is Tailscale?
+
+From the Tailscale website: https://tailscale.com/kb/1151/what-is-tailscale
+
+Tailscale is a zero-config VPN built on WireGuard that:
+- Creates a secure mesh network between your devices
+- Works through NAT and firewalls without configuration
+- Provides each device with a stable IP address (100.x.y.z)
+- Encrypts all traffic end-to-end
+- Requires no server setup or maintenance
+
+## Prerequisites
+
+### 1. Tailscale Account
+
+Create a free Tailscale account at https://tailscale.com
+
+### 2. Network Connectivity
+
+The Pager must have internet access during installation to download Tailscale binaries.
+
+### 3. Storage Space
+
+Ensure at least 85MB of free storage space:
+```bash
+df -h
+```
+
+## Installation
+
+### Method 1: Interactive Installation (Recommended)
+
+1. Copy the `tailscale_installer` directory to your Pager:
+   ```
+   /payloads/library/user/remote_access/tailscale_installer/
+   ```
+
+2. Run the installer payload via Pager UI
+
+3. Wait for installation to complete
+
+4. Run the configure payload
+
+5. Follow the on-screen prompts:
+   - Choose auto-start preference
+   - Complete authentication
+
+### Authentication
+
+1. The configure payload starts Tailscale and generates a unique URL
+2. The URL is displayed in the payload logs
+3. Visit the URL on another device (phone, laptop)
+4. Log in to your Tailscale account
+5. Approve the Pager device
+6. Authentication completes automatically
+
+**Example URL:**
+```
+https://login.tailscale.com/a/abc123def456
+```
+
+## Usage
+
+### Accessing Your Pager
+
+Once Tailscale is running, access your Pager from any device on your Tailscale network:
+
+```bash
+# SSH via Tailscale IP
+ssh root@100.x.y.z
+
+# Web interface via Tailscale IP
+http://100.x.y.z
+```
+
+Find your Pager's Tailscale IP:
+```bash
+tailscale ip -4
+```
+
+### Management via Payloads
+
+Use the dedicated Tailscale payloads for common operations:
+
+- **Tailscale Status** - Check connection status and IP
+- **Tailscale Connect** - Connect to Tailscale network
+- **Tailscale Disconnect** - Disconnect from network
+- **Tailscale Uninstaller** - Completely remove Tailscale
+
+All payloads are available in the Pager UI under:
+```
+User Payloads → tailscale → Tailscale [Operation]
+```
+
+### Configuration File
+
+Payload settings are stored in `/etc/tailscale/config`:
+
+```bash
+# View configuration
+cat /etc/tailscale/config
+
+# Example contents:
+# AUTO_START=yes
+# CONFIGURED_DATE=2026-01-01 12:30:00
+```
+
+### ACL Tags
+
+You can apply tags to your Pager device through the Tailscale admin console after authentication for automatic ACL rules (e.g., `tag:pager`, `tag:redteam`).
+
+## Troubleshooting
+
+### Installation Fails
+
+**Problem:** Download fails  
+**Solution:** Check internet connectivity, verify URL is accessible
+
+**Problem:** Extraction fails  
+**Solution:** Ensure sufficient disk space, check file integrity
+
+**Problem:** Binary installation fails  
+**Solution:** Verify write permissions to `/usr/sbin`
+
+### Authentication Issues
+
+**Problem:** Auth URL not displayed  
+**Solution:** Check payload logs for the complete URL
+
+**Problem:** Authentication timeout
+**Solution:** Complete authentication within 5 minutes, or restart
+
+### Connection Problems
+
+**Problem:** Cannot connect to Tailscale network  
+**Solution:** 
+```bash
+# Check service status
+/etc/init.d/tailscaled status
+
+# Restart service
+/etc/init.d/tailscaled restart
+
+# Check logs
+logread | grep tailscale
+```
+
+**Problem:** Tailscale IP not assigned  
+**Solution:**
+```bash
+# Verify authentication
+tailscale status
+
+# Re-authenticate if needed
+tailscale up
+```
+
+### Service Issues
+
+**Problem:** Service won't start  
+**Solution:**
+```bash
+# Check if already running
+ps | grep tailscaled
+
+# Kill existing process
+killall tailscaled
+
+# Start fresh
+/etc/init.d/tailscaled start
+```
+
+**Problem:** Service doesn't start at boot  
+**Solution:**
+```bash
+# Verify auto-start is enabled
+/etc/init.d/tailscaled enabled
+
+# Re-enable if needed
+/etc/init.d/tailscaled enable
+```
+
+## File Locations
+
+```
+/usr/sbin/tailscale          # Tailscale CLI binary
+/usr/sbin/tailscaled         # Tailscale daemon binary
+/etc/init.d/tailscaled        # Init script for service management
+/etc/tailscale/config        # Configuration file
+/var/lib/tailscale/          # State directory
+/var/run/tailscale/          # Runtime socket directory
+```
+
+## Security Considerations
+
+⚠️ **Important Security Notes:**
+
+- **Network Exposure** - Tailscale provides direct access to your Pager from any device on your network
+- **ACL Rules** - Configure Tailscale ACLs to restrict access appropriately
+- **Exit Nodes** - Be cautious when using Pager as exit node (bandwidth/legal implications)
+- **Logging** - Tailscale logs connection metadata (not payload data)
+
+## Uninstallation
+
+### Using Tailscale Uninstaller Payload
+
+Run the **Tailscale Uninstaller** payload from the Pager UI:
+```
+User Payloads → Remote Access → Tailscale Uninstaller
+```
+
+The uninstaller will:
+- Confirm the operation (double confirmation)
+- Stop and disable the service
+- Remove all binaries
+- Delete configuration and state files
+
+### Manual Uninstallation (SSH)
+
+```bash
+# Stop and disable service
+/etc/init.d/tailscaled stop
+/etc/init.d/tailscaled disable
+
+# Remove binaries
+rm -f /usr/sbin/tailscale
+rm -f /usr/sbin/tailscaled
+
+# Remove init script
+rm -f /etc/init.d/tailscaled
+
+# Remove configuration and state
+rm -rf /etc/tailscale
+rm -rf /var/lib/tailscale
+rm -rf /var/run/tailscale
+```
+
+## Changelog
+
+### Version 1.0 (2025-12-21)
+- Initial release
+- Automated installation for MIPS architecture
+- Automatic latest version detection
+- Interactive authentication
+- Auto-start configuration
+- Dedicated management payloads (status, connect, disconnect, uninstall)
+- Comprehensive error handling and DuckyScript integration
+
+## Resources
+
+- **Tailscale Documentation:** https://tailscale.com/kb/
+- **Tailscale Admin Console:** https://login.tailscale.com/admin
+- **ACL Configuration:** https://login.tailscale.com/admin/acls
+
+## License
+
+This payload is provided for educational and authorized use only. Users are solely responsible for compliance with all applicable laws and regulations.
+
+## Credits
+
+- **Author:** JAKONL
+- **Platform:** WiFi Pineapple Pager by Hak5
+- **Tailscale:** https://tailscale.com
+

--- a/library/user/remote_access/tailscale_installer/TROUBLESHOOTING.md
+++ b/library/user/remote_access/tailscale_installer/TROUBLESHOOTING.md
@@ -1,0 +1,291 @@
+# Tailscale Installer Troubleshooting Guide
+
+## Viewing Logs
+
+### Method 1: Pager UI Logs
+The Pager UI displays logs in real-time when running a payload. All `LOG` commands output to this interface.
+
+### Method 2: System Logs (SSH)
+SSH into your device and use `logread` to view system logs:
+
+```bash
+# View all recent logs
+logread | tail -n 100
+
+# Filter for Tailscale-related logs
+logread | grep -i tailscale
+
+# Follow logs in real-time
+logread -f
+```
+
+### Method 3: Payload Output Files
+Some payloads may write to temporary files in `/tmp/`:
+
+```bash
+# Check for temporary files
+ls -la /tmp/tailscale*
+
+# View temporary directory contents
+ls -la /tmp/tailscale_install/
+```
+
+## Common Installation Errors
+
+### Error: "Extraction failed"
+
+**Symptoms:**
+- Installation stops after "Download complete"
+- Error message: "Extraction failed"
+
+**Possible Causes:**
+1. Downloaded file is corrupted
+2. Not enough space in `/tmp/`
+3. tar command not available or broken
+4. Downloaded file is not a valid gzip archive
+
+**Diagnostic Steps:**
+```bash
+# Check available space
+df -h /tmp
+
+# Verify the downloaded file
+cd /tmp/tailscale_install/
+ls -lh
+file tailscale_*.tgz
+
+# Try manual extraction
+tar -xzf tailscale_*.tgz
+```
+
+**Solutions:**
+- Free up space: `rm -rf /tmp/*` (be careful!)
+- Re-run the installer (may have been a download issue)
+- Check internet connectivity: `ping 8.8.8.8`
+
+---
+
+### Error: "Extracted files not found"
+
+**Symptoms:**
+- Extraction completes but installation fails
+- Error message: "Extracted files not found"
+
+**Possible Causes:**
+1. Archive structure is different than expected
+2. Extraction created files in unexpected location
+3. Archive is empty or corrupted
+
+**Diagnostic Steps:**
+```bash
+# Check what was extracted
+cd /tmp/tailscale_install/
+ls -la
+
+# Look for any directories
+find . -type d
+
+# Look for binaries
+find . -name "tailscale*" -type f
+```
+
+**Solutions:**
+- Check the enhanced logs to see the actual directory structure
+- The installer now logs the contents of the temp directory
+- Look for the actual location of the binaries in the logs
+
+---
+
+### Error: "Failed to copy tailscale binary"
+
+**Symptoms:**
+- Binaries found but copy operation fails
+- Error message: "Failed to copy tailscale binary"
+
+**Possible Causes:**
+1. `/usr/sbin/` is read-only or full
+2. Permission denied
+3. Existing files are in use
+
+**Diagnostic Steps:**
+```bash
+# Check /usr/sbin permissions
+ls -ld /usr/sbin
+
+# Check available space
+df -h /usr
+
+# Check if files already exist
+ls -la /usr/sbin/tailscale*
+
+# Check if processes are using the files
+lsof | grep tailscale
+```
+
+**Solutions:**
+```bash
+# Stop existing Tailscale service
+/etc/init.d/tailscaled stop 2>/dev/null
+
+# Remove old binaries
+rm -f /usr/sbin/tailscale /usr/sbin/tailscaled
+
+# Re-run installer
+```
+
+---
+
+### Error: "Could not determine version"
+
+**Symptoms:**
+- Installation fails immediately
+- Error message: "Could not determine version"
+
+**Possible Causes:**
+1. No internet connectivity
+2. Tailscale repository is unreachable
+3. Repository format has changed
+
+**Diagnostic Steps:**
+```bash
+# Test internet connectivity
+ping -c 3 8.8.8.8
+ping -c 3 pkgs.tailscale.com
+
+# Test repository access
+wget -qO- https://pkgs.tailscale.com/stable/ | head -n 20
+
+# Check DNS resolution
+nslookup pkgs.tailscale.com
+```
+
+**Solutions:**
+- Check network connectivity
+- The installer will fall back to version 1.76.1 if detection fails
+- Check the logs to see which fallback was used
+
+---
+
+### Error: "Download failed"
+
+**Symptoms:**
+- Version detected but download fails
+- Error message: "Download failed. Check network connection."
+
+**Possible Causes:**
+1. No internet connectivity
+2. Incorrect URL
+3. File doesn't exist for mipsle architecture
+4. Network timeout
+
+**Diagnostic Steps:**
+```bash
+# Check the logged download URL
+# Then try manually:
+wget https://pkgs.tailscale.com/stable/tailscale_X.Y.Z_mipsle.tgz
+
+# Check available files
+wget -qO- https://pkgs.tailscale.com/stable/ | grep mipsle
+```
+
+**Solutions:**
+- Verify internet connectivity
+- Check if the version exists for mipsle architecture
+- Try a different network
+- Wait and retry (may be temporary network issue)
+
+---
+
+## Installation Process Debug Checklist
+
+The enhanced installer now logs detailed information at each step:
+
+1. ✅ **Version Detection**
+   - Logs the detected version
+   - Shows the download URL
+   - Falls back to known version if needed
+
+2. ✅ **Download**
+   - Shows download progress
+   - Verifies file exists after download
+   - Logs file size
+
+3. ✅ **Extraction**
+   - Shows extraction command
+   - Lists files after extraction
+   - Verifies archive integrity
+
+4. ✅ **Binary Installation**
+   - Lists temp directory contents
+   - Shows extracted directory path
+   - Lists extracted directory contents
+   - Verifies binaries exist before copying
+   - Shows copy operations
+   - Verifies installed files
+
+5. ✅ **Service Creation**
+   - Shows init script creation
+   - Verifies script permissions
+
+## Getting Help
+
+If you're still experiencing issues:
+
+1. **Collect Logs:**
+   ```bash
+   # Save full logs
+   logread > /tmp/tailscale_install_logs.txt
+   
+   # Save directory contents
+   ls -laR /tmp/tailscale_install/ > /tmp/directory_listing.txt
+   ```
+
+2. **Check System Info:**
+   ```bash
+   # Architecture
+   uname -m
+   
+   # Available space
+   df -h
+   
+   # Memory
+   free -m
+   ```
+
+3. **Share Information:**
+   - Error message from Pager UI
+   - Relevant log entries
+   - System information
+   - Steps to reproduce
+
+## Manual Installation
+
+If the automated installer continues to fail, you can install manually:
+
+```bash
+# Download manually
+cd /tmp
+wget https://pkgs.tailscale.com/stable/tailscale_1.76.1_mipsle.tgz
+
+# Extract
+tar -xzf tailscale_1.76.1_mipsle.tgz
+
+# Find the binaries
+find . -name "tailscale" -type f
+find . -name "tailscaled" -type f
+
+# Copy to /usr/sbin (adjust path based on find results)
+cp ./tailscale_*/tailscale /usr/sbin/
+cp ./tailscale_*/tailscaled /usr/sbin/
+chmod +x /usr/sbin/tailscale*
+
+# Verify
+/usr/sbin/tailscale version
+```
+
+Then run the configure.sh script separately:
+```bash
+cd /payloads/library/user/remote_access/tailscale_installer/
+./configure.sh
+```
+

--- a/library/user/remote_access/tailscale_installer/payload.sh
+++ b/library/user/remote_access/tailscale_installer/payload.sh
@@ -1,0 +1,429 @@
+#!/bin/bash
+# Title: Tailscale Installer
+# Description: Install and configure Tailscale
+# Author: JAKONL
+# Version: 1.0
+#
+# This payload installs Tailscale VPN on the Pager, enabling secure remote access
+# from anywhere. Supports both interactive authentication and auth key setup.
+#
+# LED State Descriptions:
+# Cyan Blink - Downloading Tailscale
+# Amber Blink - Installing binaries
+# Green Solid - Installation successful
+# Red Blink - Installation failed
+
+LOG "=== Tailscale Installer ==="
+LOG "Starting installation process..."
+LOG ""
+LOG "System Architecture: $(uname -m)"
+LOG ""
+LOG "📋 Detailed logs are available via:"
+LOG "   - Pager UI: Check the payload logs"
+LOG "   - SSH: logread | grep -i tailscale"
+LOG "   - SSH: logread | tail -n 100"
+LOG ""
+
+# ============================================
+# CONFIGURATION
+# ============================================
+
+# Tailscale architecture and repository
+# Auto-detect architecture, fallback to mipsle
+DEVICE_ARCH=$(uname -m)
+case "$DEVICE_ARCH" in
+    mips|mipsel)
+        TAILSCALE_ARCH="mipsle"
+        ;;
+    *)
+        # Default to mipsle for WiFi Pineapple
+        TAILSCALE_ARCH="mipsle"
+        ;;
+esac
+
+TAILSCALE_BASE_URL="https://pkgs.tailscale.com/stable"
+
+# Installation paths
+INSTALL_DIR="/usr/sbin"
+INIT_SCRIPT="/etc/init.d/tailscaled"
+CONFIG_DIR="/etc/tailscale"
+STATE_DIR="/var/lib/tailscale"
+TMP_DIR="/tmp/tailscale_install"
+
+# Configuration file
+CONFIG_FILE="$CONFIG_DIR/config"
+
+# ============================================
+# HELPER FUNCTIONS
+# ============================================
+
+cleanup() {
+    LOG "Cleaning up temporary files..."
+    rm -rf "$TMP_DIR"
+}
+
+check_installed() {
+    if [ -f "$INSTALL_DIR/tailscale" ] && [ -f "$INSTALL_DIR/tailscaled" ]; then
+        return 0
+    fi
+    return 1
+}
+
+get_latest_version() {
+    LOG "Detecting latest Tailscale version..."
+
+    # Try to get the latest version from the stable repository
+    # The repository lists files, we'll parse for the latest mipsle package
+    local version_list=$(wget -qO- "${TAILSCALE_BASE_URL}/" 2>/dev/null | \
+        grep -o "tailscale_[0-9.]*_${TAILSCALE_ARCH}.tgz" | \
+        grep -o "[0-9.]*" | \
+        sort -V | \
+        tail -n 1)
+
+    if [ -z "$version_list" ]; then
+        # Fallback: try to get version from the latest stable track
+        LOG "Trying alternative version detection..."
+        version_list=$(wget -qO- "https://pkgs.tailscale.com/stable/?mode=json" 2>/dev/null | \
+            grep -o '"Version":"[^"]*"' | \
+            head -n 1 | \
+            cut -d'"' -f4)
+    fi
+
+    if [ -z "$version_list" ]; then
+        # Final fallback: use a known stable version
+        LOG yellow "Could not detect latest version, using fallback"
+        echo "1.92.3"
+        return
+    fi
+
+    LOG "Latest version detected: $version_list"
+    echo "$version_list"
+}
+
+# ============================================
+# DOWNLOAD AND INSTALL
+# ============================================
+
+download_tailscale() {
+    # Get the latest version
+    local version=$(get_latest_version)
+
+    if [ -z "$version" ]; then
+        ERROR_DIALOG "Could not determine version"
+        LOG red "ERROR: Failed to detect Tailscale version"
+        exit 1
+    fi
+
+    LOG "Will install Tailscale version: $version"
+
+    LOG "Creating temporary directory..."
+    mkdir -p "$TMP_DIR"
+    cd "$TMP_DIR" || exit 1
+
+    local filename="tailscale_${version}_${TAILSCALE_ARCH}.tgz"
+    local url="${TAILSCALE_BASE_URL}/${filename}"
+
+    LOG "Downloading Tailscale ${version} for ${TAILSCALE_ARCH}..."
+    LOG "URL: $url"
+    local spinner_id=$(START_SPINNER "Downloading")
+
+    if ! wget -q "$url" -O "$filename"; then
+        STOP_SPINNER $spinner_id
+        ERROR_DIALOG "Download failed. Check network connection."
+        LOG red "ERROR: Failed to download from $url"
+        cleanup
+        exit 1
+    fi
+
+    STOP_SPINNER $spinner_id
+    LOG green "Download complete"
+
+    # Verify download
+    LOG "Verifying downloaded file..."
+    if [ ! -f "$filename" ]; then
+        ERROR_DIALOG "Downloaded file not found"
+        LOG red "ERROR: $filename does not exist after download"
+        cleanup
+        exit 1
+    fi
+
+    local filesize=$(ls -lh "$filename" | awk '{print $5}')
+    LOG "Downloaded file size: $filesize"
+
+    LOG "Extracting archive..."
+    LOG "Running: tar -xzf $filename"
+
+    if ! tar -xzf "$filename" 2>&1 | while read line; do LOG "$line"; done; then
+        ERROR_DIALOG "Extraction failed"
+        LOG red "ERROR: Failed to extract $filename"
+        LOG "Checking file type:"
+        file "$filename" 2>&1 | while read line; do LOG "$line"; done
+        cleanup
+        exit 1
+    fi
+
+    LOG green "Extraction complete"
+}
+
+install_binaries() {
+    LOG "Installing Tailscale binaries..."
+
+    # Find the extracted directory (exclude .tgz files, only find directories)
+    LOG "Searching for extracted directory..."
+
+    # Try multiple patterns to find the extracted directory
+    local extract_dir=""
+
+    # First try: Look for any subdirectory (most reliable)
+    extract_dir=$(find "$TMP_DIR" -mindepth 1 -maxdepth 1 -type d | grep -v "\.tgz" | head -n 1)
+
+    # Second try: Look specifically for tailscale_* directories
+    if [ -z "$extract_dir" ]; then
+        extract_dir=$(find "$TMP_DIR" -mindepth 1 -maxdepth 1 -type d -name "tailscale_*" | head -n 1)
+    fi
+
+    # Third try: Look in any subdirectory for the binaries
+    if [ -z "$extract_dir" ]; then
+        LOG yellow "No obvious directory found, searching for binaries..."
+        local binary_path=$(find "$TMP_DIR" -name "tailscale" -type f ! -name "*.tgz" | head -n 1)
+        if [ -n "$binary_path" ]; then
+            extract_dir=$(dirname "$binary_path")
+            LOG "Found binaries in: $extract_dir"
+        fi
+    fi
+
+    if [ -z "$extract_dir" ]; then
+        ERROR_DIALOG "Extracted files not found"
+        LOG red "ERROR: Could not find extracted directory in $TMP_DIR"
+        LOG "Available directories:"
+        find "$TMP_DIR" -type d 2>&1 | while read line; do LOG "$line"; done
+        LOG "Available files:"
+        find "$TMP_DIR" -type f 2>&1 | while read line; do LOG "$line"; done
+        cleanup
+        exit 1
+    fi
+
+    LOG green "Found extracted directory: $extract_dir"
+
+    # Check if binaries exist in extracted directory
+    if [ ! -f "$extract_dir/tailscale" ]; then
+        ERROR_DIALOG "tailscale binary not found"
+        LOG red "ERROR: $extract_dir/tailscale does not exist"
+        cleanup
+        exit 1
+    fi
+
+    if [ ! -f "$extract_dir/tailscaled" ]; then
+        ERROR_DIALOG "tailscaled binary not found"
+        LOG red "ERROR: $extract_dir/tailscaled does not exist"
+        cleanup
+        exit 1
+    fi
+
+    LOG "Both binaries found, copying to $INSTALL_DIR..."
+
+    # Show file sizes (using ls since stat is not available on Pager)
+    local tailscale_size_human=$(ls -lh "$extract_dir/tailscale" | awk '{print $5}')
+    local tailscaled_size_human=$(ls -lh "$extract_dir/tailscaled" | awk '{print $5}')
+    local tailscale_size_bytes=$(ls -l "$extract_dir/tailscale" | awk '{print $5}')
+    local tailscaled_size_bytes=$(ls -l "$extract_dir/tailscaled" | awk '{print $5}')
+
+    # Calculate total size for combined progress
+    local total_size_bytes=$((tailscale_size_bytes + tailscaled_size_bytes))
+    local total_size_mb=$((total_size_bytes / 1048576))
+
+    LOG "tailscale binary size: $tailscale_size_human"
+    LOG "tailscaled binary size: $tailscaled_size_human"
+    LOG "Total size to copy: ${total_size_mb}MB"
+    LOG yellow "Note: Moving binaries from TMP to Persistent takes ~10 minutes due to storage contraints..."
+    LOG ""
+    LOG "Copying binaries with combined progress..."
+    LOG "Progress updates every 10 seconds..."
+
+    # Copy tailscale binary in background
+    cp "$extract_dir/tailscale" "$INSTALL_DIR/tailscale" &
+    local cp_pid=$!
+
+    # Monitor progress for both binaries combined
+    local wait_count=0
+    local copying_first=true
+
+    while true; do
+        sleep 10
+        wait_count=$((wait_count + 5))
+
+        # Calculate current total copied (both files)
+        local tailscale_current=0
+        local tailscaled_current=0
+
+        if [ -f "$INSTALL_DIR/tailscale" ]; then
+            tailscale_current=$(ls -l "$INSTALL_DIR/tailscale" 2>/dev/null | awk '{print $5}')
+            [ -z "$tailscale_current" ] && tailscale_current=0
+        fi
+
+        if [ -f "$INSTALL_DIR/tailscaled" ]; then
+            tailscaled_current=$(ls -l "$INSTALL_DIR/tailscaled" 2>/dev/null | awk '{print $5}')
+            [ -z "$tailscaled_current" ] && tailscaled_current=0
+        fi
+
+        local total_current=$((tailscale_current + tailscaled_current))
+        local total_current_mb=$((total_current / 1048576))
+
+        # Calculate overall percentage
+        if [ "$total_size_bytes" -gt 0 ]; then
+            local percent=$((total_current * 100 / total_size_bytes))
+            LOG "  Overall Progress: ${percent}% (${total_current_mb}MB / ${total_size_mb}MB) - ${wait_count}s elapsed"
+        else
+            LOG "  Copying... ${wait_count}s elapsed"
+        fi
+
+        # Check if first copy is done, start second copy
+        if [ "$copying_first" = true ] && ! kill -0 $cp_pid 2>/dev/null; then
+            # First copy finished, check if successful
+            wait $cp_pid
+            local cp_result=$?
+
+            if [ $cp_result -ne 0 ]; then
+                ERROR_DIALOG "Failed to copy tailscale binary"
+                LOG red "ERROR: Failed to copy $extract_dir/tailscale to $INSTALL_DIR/"
+                LOG "Checking permissions on $INSTALL_DIR:"
+                ls -ld "$INSTALL_DIR" 2>&1 | while read line; do LOG "$line"; done
+                cleanup
+                exit 1
+            fi
+
+            LOG "  tailscale binary copied, continuing with tailscaled..."
+
+            # Start second copy
+            cp "$extract_dir/tailscaled" "$INSTALL_DIR/tailscaled" &
+            cp_pid=$!
+            copying_first=false
+        fi
+
+        # Check if second copy is done
+        if [ "$copying_first" = false ] && ! kill -0 $cp_pid 2>/dev/null; then
+            # Second copy finished
+            wait $cp_pid
+            local cp_result=$?
+
+            if [ $cp_result -ne 0 ]; then
+                ERROR_DIALOG "Failed to copy tailscaled binary"
+                LOG red "ERROR: Failed to copy $extract_dir/tailscaled to $INSTALL_DIR/"
+                cleanup
+                exit 1
+            fi
+
+            # Both copies complete
+            break
+        fi
+    done
+
+    LOG ""
+    LOG green "✓ Both binaries copied successfully (${wait_count}s total)"
+    LOG ""
+
+    # Set permissions
+    LOG "Setting executable permissions..."
+    chmod +x "$INSTALL_DIR/tailscale"
+    chmod +x "$INSTALL_DIR/tailscaled"
+
+    LOG green "Binaries installed successfully"
+}
+
+create_directories() {
+    LOG "Creating configuration directories..."
+    mkdir -p "$CONFIG_DIR"
+    mkdir -p "$STATE_DIR"
+    LOG "Directories created"
+}
+
+create_init_script() {
+    LOG "Creating init.d script..."
+    
+    cat > "$INIT_SCRIPT" << 'INITEOF'
+#!/bin/sh /etc/rc.common
+
+START=99
+STOP=10
+
+USE_PROCD=1
+
+start_service() {
+    procd_open_instance
+    procd_set_param command /usr/sbin/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock
+    procd_set_param respawn
+    procd_set_param stdout 1
+    procd_set_param stderr 1
+    procd_close_instance
+}
+
+stop_service() {
+    /usr/sbin/tailscale down
+}
+INITEOF
+
+    chmod +x "$INIT_SCRIPT"
+    LOG "Init script created"
+}
+
+# ============================================
+# MAIN INSTALLATION
+# ============================================
+
+main_install() {
+    LOG "=== Tailscale Installation Started ==="
+    
+    # Check if already installed
+    if check_installed; then
+        resp=$(CONFIRMATION_DIALOG "Tailscale already installed. Reinstall?")
+        case $? in
+            $DUCKYSCRIPT_REJECTED|$DUCKYSCRIPT_ERROR)
+                LOG "Installation cancelled"
+                exit 0
+                ;;
+        esac
+        
+        case "$resp" in
+            $DUCKYSCRIPT_USER_DENIED)
+                LOG "User chose not to reinstall"
+                exit 0
+                ;;
+        esac
+    fi
+    
+    # Download and extract
+    download_tailscale
+    
+    # Install binaries
+    install_binaries
+    
+    # Create directories
+    create_directories
+    
+    # Create init script
+    create_init_script
+    
+    # Cleanup
+    cleanup
+    
+    LOG "=== Installation Complete ==="
+    LOG ""
+    LOG green "✓ Tailscale binaries installed"
+    LOG green "✓ Init script created"
+    LOG green "✓ Directories configured"
+    LOG ""
+    LOG yellow "⚠ NEXT STEP REQUIRED:"
+    LOG "Run the 'Tailscale Configure' payload to complete setup"
+    LOG ""
+    LOG "Navigate to:"
+    LOG "  User Payloads → Remote Access → Tailscale Configure"
+    LOG ""
+
+    ALERT "Install complete! Run Tailscale Configure next"
+
+    # Prompt user to continue
+    PROMPT "Installation successful! Please run 'Tailscale Configure' payload next to complete setup."
+}
+
+# Execute installation
+main_install

--- a/library/user/remote_access/tailscale_status/payload.sh
+++ b/library/user/remote_access/tailscale_status/payload.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Title: Tailscale Status
+# Description: Show Tailscale connection status
+# Author: JAKONL
+# Version: 1.0
+# Category: Remote-Access
+
+LOG "=== Tailscale Status ==="
+
+# ============================================
+# CONFIGURATION
+# ============================================
+
+INSTALL_DIR="/usr/sbin"
+TAILSCALE="$INSTALL_DIR/tailscale"
+
+# ============================================
+# MAIN
+# ============================================
+
+if [ ! -f "$TAILSCALE" ]; then
+    ERROR_DIALOG "Tailscale not installed"
+    LOG red "ERROR: Tailscale is not installed"
+    exit 1
+fi
+
+LOG "Checking Tailscale status..."
+
+# Get status
+status_output=$("$TAILSCALE" status 2>&1)
+status_code=$?
+
+if [ $status_code -ne 0 ]; then
+    ERROR_DIALOG "Failed to get status"
+    LOG red "ERROR: Could not get Tailscale status"
+    LOG "$status_output"
+    exit 1
+fi
+
+# Get IP address
+ip_output=$("$TAILSCALE" ip -4 2>&1)
+tailscale_ip=$(echo "$ip_output" | head -n 1)
+
+# Check if connected
+if echo "$status_output" | grep -q "stopped"; then
+    ALERT "Tailscale: Stopped"
+    LOG yellow "Status: Stopped"
+    LOG "Tailscale is not running"
+elif echo "$status_output" | grep -q "NeedsLogin"; then
+    ALERT "Tailscale: Needs Login"
+    LOG yellow "Status: Needs Authentication"
+    LOG "Run Tailscale Installer to authenticate"
+else
+    ALERT "Connected: $tailscale_ip"
+    LOG green "Status: Connected"
+    LOG "Tailscale IP: $tailscale_ip"
+fi
+
+# Log full status
+LOG "--- Full Status ---"
+echo "$status_output" | while IFS= read -r line; do
+    LOG "$line"
+done
+
+# Show network info
+LOG "--- Network Info ---"
+netmap=$("$TAILSCALE" netmap 2>&1)
+if [ $? -eq 0 ]; then
+    echo "$netmap" | head -n 10 | while IFS= read -r line; do
+        LOG "$line"
+    done
+else
+    LOG "Network map not available"
+fi
+
+LOG "=== Status Check Complete ==="
+

--- a/library/user/remote_access/tailscale_uninstaller/payload.sh
+++ b/library/user/remote_access/tailscale_uninstaller/payload.sh
@@ -1,0 +1,152 @@
+#!/bin/bash
+# Title: Tailscale Uninstaller
+# Description: Remove Tailscale from device
+# Author: JAKONL
+# Version: 1.0
+# Category: Remote-Access
+
+LOG "=== Tailscale Uninstaller ==="
+LOG "Preparing to uninstall Tailscale..."
+
+# ============================================
+# CONFIGURATION
+# ============================================
+
+INSTALL_DIR="/usr/sbin"
+INIT_SCRIPT="/etc/init.d/tailscaled"
+CONFIG_DIR="/etc/tailscale"
+STATE_DIR="/var/lib/tailscale"
+RUN_DIR="/var/run/tailscale"
+
+# ============================================
+# FUNCTIONS
+# ============================================
+
+check_installed() {
+    if [ ! -f "$INSTALL_DIR/tailscale" ] && [ ! -f "$INSTALL_DIR/tailscaled" ]; then
+        return 1
+    fi
+    return 0
+}
+
+uninstall_tailscale() {
+    LOG "Stopping Tailscale service..."
+    
+    # Stop and disable service if it exists
+    if [ -f "$INIT_SCRIPT" ]; then
+        "$INIT_SCRIPT" stop 2>/dev/null
+        "$INIT_SCRIPT" disable 2>/dev/null
+        LOG "Service stopped and disabled"
+    fi
+    
+    # Disconnect from network
+    if [ -f "$INSTALL_DIR/tailscale" ]; then
+        LOG "Disconnecting from Tailscale network..."
+        "$INSTALL_DIR/tailscale" down 2>/dev/null
+    fi
+    
+    LOG "Removing Tailscale files..."
+    
+    # Remove binaries
+    rm -f "$INSTALL_DIR/tailscale"
+    rm -f "$INSTALL_DIR/tailscaled"
+    LOG "Binaries removed"
+    
+    # Remove init script
+    rm -f "$INIT_SCRIPT"
+    LOG "Init script removed"
+    
+    # Remove configuration and state
+    rm -rf "$CONFIG_DIR"
+    rm -rf "$STATE_DIR"
+    rm -rf "$RUN_DIR"
+    LOG "Configuration and state removed"
+    
+    return 0
+}
+
+# ============================================
+# MAIN
+# ============================================
+
+main_uninstall() {
+    LOG "=== Tailscale Uninstallation Started ==="
+    
+    # Check if Tailscale is installed
+    if ! check_installed; then
+        ALERT "Tailscale not installed"
+        LOG "Tailscale is not installed on this device"
+        exit 0
+    fi
+    
+    # Confirm uninstallation
+    resp=$(CONFIRMATION_DIALOG "Uninstall Tailscale?")
+    case $? in
+        $DUCKYSCRIPT_REJECTED|$DUCKYSCRIPT_ERROR)
+            LOG "Uninstall cancelled"
+            ALERT "Uninstall cancelled"
+            exit 0
+            ;;
+    esac
+    
+    case "$resp" in
+        $DUCKYSCRIPT_USER_CONFIRMED)
+            LOG "User confirmed uninstallation"
+            
+            # Show warning about data loss
+            resp2=$(CONFIRMATION_DIALOG "This will remove all Tailscale data. Continue?")
+            case $? in
+                $DUCKYSCRIPT_REJECTED|$DUCKYSCRIPT_ERROR)
+                    LOG "Uninstall cancelled at warning"
+                    ALERT "Uninstall cancelled"
+                    exit 0
+                    ;;
+            esac
+            
+            case "$resp2" in
+                $DUCKYSCRIPT_USER_CONFIRMED)
+                    LOG "Proceeding with uninstallation..."
+                    
+                    # Perform uninstallation
+                    spinner_id=$(START_SPINNER "Uninstalling")
+                    
+                    if uninstall_tailscale; then
+                        STOP_SPINNER $spinner_id
+                        ALERT "Tailscale uninstalled!"
+                        LOG "=== Uninstallation Complete ==="
+                        LOG green "Tailscale has been completely removed"
+                    else
+                        STOP_SPINNER $spinner_id
+                        ERROR_DIALOG "Uninstall failed"
+                        LOG red "ERROR: Uninstallation failed"
+                        exit 1
+                    fi
+                    ;;
+                $DUCKYSCRIPT_USER_DENIED)
+                    LOG "User cancelled at final confirmation"
+                    ALERT "Uninstall cancelled"
+                    exit 0
+                    ;;
+                *)
+                    LOG "ERROR: Unknown response: $resp2"
+                    ERROR_DIALOG "Unknown response"
+                    exit 1
+                    ;;
+            esac
+            ;;
+        $DUCKYSCRIPT_USER_DENIED)
+            LOG "User declined uninstallation"
+            ALERT "Uninstall cancelled"
+            exit 0
+            ;;
+        *)
+            LOG "ERROR: Unknown response: $resp"
+            ERROR_DIALOG "Unknown response"
+            exit 1
+            ;;
+    esac
+}
+
+# Execute uninstallation
+main_uninstall
+


### PR DESCRIPTION
A fun weekend project to make Tailscale installation, configuration, and quick tasks a breeze from the pager native interface. 

One item I was hoping to get working but couldn't fit on the screen was a QR code for the tailscale authentication URL. 

_Appreciate any feedback!_

#### Implementation
The tailscale payloads help a user achieve common tasks in managing their Pineapple Pager's Tailscale services:
- Installation
- Authentication
- Get current tailscale IP address
- Service Start/Stop
- Uninstallation

#### Inspiration
I faced some challenges while onboarding my Pager to my Tailscale network. A non-comprehensive list includes:
- `opkg` Tailscale packages out of date (~ March 2024) with known security vulnerabilities
 ```
 root@pager:~/payloads/user/remote_access# opkg info tailscale
Package: tailscale
Version: 1.80.3-r1
```
- Managing `tailscale` connectivity with `opkg` installation requires shell
- Became confused as `uname -m` reports `mips` though the Pager requires packages built for `mipsel`