### PR TITLE
Move tailscale state to persistent storage

### DIFF
--- a/library/user/remote_access/tailscale_configure/README.md
+++ b/library/user/remote_access/tailscale_configure/README.md
@@ -143,7 +143,7 @@ A complete suite of payloads for managing Tailscale on the WiFi Pineapple Pager.
 - **Binaries:** `/usr/sbin/tailscale`, `/usr/sbin/tailscaled`
 - **Init Script:** `/etc/init.d/tailscaled`
 - **Configuration:** `/etc/tailscale/`
-- **State:** `/var/lib/tailscale/`
+- **State:** `/root/.tailscale/`
 - **Runtime:** `/var/run/tailscale/`
 
 ## Manual Commands (SSH)

--- a/library/user/remote_access/tailscale_configure/payload.sh
+++ b/library/user/remote_access/tailscale_configure/payload.sh
@@ -14,7 +14,7 @@ INSTALL_DIR="/usr/sbin"
 INIT_SCRIPT="/etc/init.d/tailscaled"
 CONFIG_DIR="/etc/tailscale"
 CONFIG_FILE="$CONFIG_DIR/config"
-STATE_DIR="/var/lib/tailscale"
+STATE_DIR="/root/.tailscale"
 
 # ============================================
 # HELPER FUNCTIONS

--- a/library/user/remote_access/tailscale_connect/payload.sh
+++ b/library/user/remote_access/tailscale_connect/payload.sh
@@ -33,7 +33,7 @@ if ! pgrep tailscaled > /dev/null; then
     if [ -f "$INIT_SCRIPT" ]; then
         "$INIT_SCRIPT" start
     else
-        "$TAILSCALED" --state=/var/lib/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock &
+        "$TAILSCALED" --state=/root/.tailscale/tailscaled.state --statedir=/root/.tailscale/ --socket=/var/run/tailscale/tailscaled.sock &
     fi
     sleep 3
 fi

--- a/library/user/remote_access/tailscale_installer/README.md
+++ b/library/user/remote_access/tailscale_installer/README.md
@@ -219,7 +219,7 @@ killall tailscaled
 /usr/sbin/tailscaled         # Tailscale daemon binary
 /etc/init.d/tailscaled        # Init script for service management
 /etc/tailscale/config        # Configuration file
-/var/lib/tailscale/          # State directory
+/root/.tailscale/            # State directory
 /var/run/tailscale/          # Runtime socket directory
 ```
 
@@ -263,7 +263,7 @@ rm -f /etc/init.d/tailscaled
 
 # Remove configuration and state
 rm -rf /etc/tailscale
-rm -rf /var/lib/tailscale
+rm -rf /root/.tailscale
 rm -rf /var/run/tailscale
 ```
 

--- a/library/user/remote_access/tailscale_installer/payload.sh
+++ b/library/user/remote_access/tailscale_installer/payload.sh
@@ -47,7 +47,7 @@ TAILSCALE_BASE_URL="https://pkgs.tailscale.com/stable"
 INSTALL_DIR="/usr/sbin"
 INIT_SCRIPT="/etc/init.d/tailscaled"
 CONFIG_DIR="/etc/tailscale"
-STATE_DIR="/var/lib/tailscale"
+STATE_DIR="/root/.tailscale"
 TMP_DIR="/tmp/tailscale_install"
 
 # Configuration file
@@ -350,7 +350,7 @@ USE_PROCD=1
 
 start_service() {
     procd_open_instance
-    procd_set_param command /usr/sbin/tailscaled --state=/var/lib/tailscale/tailscaled.state --socket=/var/run/tailscale/tailscaled.sock
+    procd_set_param command /usr/sbin/tailscaled --state=/root/.tailscale/tailscaled.state --statedir=/root/.tailscale/ --socket=/var/run/tailscale/tailscaled.sock
     procd_set_param respawn
     procd_set_param stdout 1
     procd_set_param stderr 1

--- a/library/user/remote_access/tailscale_uninstaller/payload.sh
+++ b/library/user/remote_access/tailscale_uninstaller/payload.sh
@@ -15,7 +15,7 @@ LOG "Preparing to uninstall Tailscale..."
 INSTALL_DIR="/usr/sbin"
 INIT_SCRIPT="/etc/init.d/tailscaled"
 CONFIG_DIR="/etc/tailscale"
-STATE_DIR="/var/lib/tailscale"
+STATE_DIR="/root/.tailscale"
 RUN_DIR="/var/run/tailscale"
 
 # ============================================


### PR DESCRIPTION
It was brought to my attention that the `/var` directory is stored within the `/tmp` mount point which is a Ramdisk and is lost on reboot. 

To ensure the tailscale service is able to start automatically after reboot this PR changes the tailscale state directory from `/var/lib/tailscale` to `/root/.tailscale` 

Thanks @cyberpunked1985