### PR TITLE
Cleanup blank line from the ssid_chaos payload

### DIFF
--- a/library/user/prank/ssid_chaos/payload.sh
+++ b/library/user/prank/ssid_chaos/payload.sh
@@ -316,7 +316,6 @@ show_menu() {
 6. Horror
 7. Gamer
 8. Movies
-
 9. Stop Broadcast
 10. Clear Pool
 0. Exit"


### PR DESCRIPTION
Removed a blank line in the "show_menu" function. Only cosmetic/UI due to the unintended whitespace.