### PR TITLE
Add Client Access Manager utility for remote management over wlan0cli

### DIFF
--- a/library/user/general/client-access-manager/README.md
+++ b/library/user/general/client-access-manager/README.md
@@ -1,0 +1,48 @@
+# Client Access Manager
+
+### v1.0
+
+**Author:** PanicAcid  
+**Interface:** Client WiFi (`wlan0cli`)
+
+---
+
+## Overview
+
+**Client Access Manager** is a management utility for the Hak5 WiFi Pineapple Pager. It provides a controlled method for enabling administrative access (Web UI and SSH) over the Client WiFi interface. This allows for remote device management via a local area network (LAN) without requiring a direct connection to the Management AP.
+
+This tool implements a specific firewall exception for the Client interface while maintaining the default security posture of the device's other network zones.
+
+---
+
+## Functional Logic
+
+This utility manages the OpenWrt firewall configuration through the following technical processes:
+
+* **Rule Specification** The script defines a targeted `ACCEPT` rule for the `wan` zone, explicitly opening TCP ports `22` (SSH) and `1471` (Web UI).
+  
+* **Rule Prioritization** Utilizes `uci reorder` to position the management rule at the top of the firewall chain (Index 0). This ensures the exception is processed before the system's default rejection rules.
+
+* **Interface Integration** Built using the Pager’s native `CONFIRMATION_DIALOG` system for hardware-level interaction, ensuring consistent behavior with official system payloads.
+
+* **Network Status Reporting** Upon activation, the utility identifies the current IPv4 address assigned to the `wlan0cli` interface and outputs the full management URL to the system log.
+
+* **Configuration Management** When access is revoked, the utility performs a full deletion of the custom rule from the configuration and restarts the firewall service to restore the factory security state.
+
+---
+
+## Usage
+
+The utility functions as a state-aware toggle. The interface prompts will update based on the current configuration:
+
+### Enabling Management Access
+1. Connect the Pager to a local Wi-Fi network (Client Mode).
+2. Execute **Client Access Manager** from the User menu.
+3. Select 'Yes' when prompted: *"Management Access is LOCKED. Open on Client WiFi?"*
+4. The system will display the active Client IP and management URL.
+
+### Disabling Management Access
+1. Execute the utility again from the User menu.
+2. Select 'Yes' when prompted: *"Management Access is OPEN on Client WiFi. Lock it now?"*
+3. The utility will remove the exception and reload the firewall configuration.
+

--- a/library/user/general/client-access-manager/extension.json
+++ b/library/user/general/client-access-manager/extension.json
@@ -1,0 +1,7 @@
+{
+    "name": "Client Access Manager",
+    "version": "1.0",
+    "description": "Toggles SSH/WebUI on Client AP WiFi",
+    "author": "PanicAcid",
+    "executable": "payload.sh"
+}

--- a/library/user/general/client-access-manager/payload.sh
+++ b/library/user/general/client-access-manager/payload.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Title: Client Access Manager
+# Author: PanicAcid
+# Description: Toggles SSH and Web UI access on the Client WiFi interface with IP reporting.
+# Version: 1.0
+
+RULE_NAME="dev_access_rule"
+
+# 1. State Verification
+# Checks the uci configuration to determine if the management rule is active.
+CURRENT_STATE=$(uci get firewall.$RULE_NAME.enabled 2>/dev/null || echo "0")
+
+if [ "$CURRENT_STATE" == "1" ]; then
+    MSG="Management Access is OPEN on Client WiFi. Lock it now?"
+else
+    MSG="Management Access is LOCKED. Open on Client WiFi?"
+fi
+
+# 2. User Interaction
+# Utilizes the native Pager hardware dialog system.
+RESP=$(CONFIRMATION_DIALOG "$MSG")
+
+# 3. Execution Logic
+case "$RESP" in
+    $DUCKYSCRIPT_USER_CONFIRMED)
+        if [ "$CURRENT_STATE" == "1" ]; then
+            LOG "Revoking management access..."
+            
+            # Remove the custom firewall rule to restore factory security state.
+            uci delete firewall.$RULE_NAME 2>/dev/null
+            uci commit firewall
+            fw4 restart
+            
+            LOG "[*] Access Restricted"
+        else
+            LOG "Configuring firewall exception..."
+            
+            # Define a targeted ACCEPT rule for the wan (Client WiFi) zone.
+            uci set firewall.$RULE_NAME=rule
+            uci set firewall.$RULE_NAME.name='Allow-Dev-Access'
+            uci set firewall.$RULE_NAME.src='wan'
+            uci set firewall.$RULE_NAME.dest_port='22 1471'
+            uci set firewall.$RULE_NAME.proto='tcp'
+            uci set firewall.$RULE_NAME.target='ACCEPT'
+            uci set firewall.$RULE_NAME.enabled='1'
+            
+            # Prioritize the rule at Index 0 to ensure it precedes default reject rules.
+            uci reorder firewall.$RULE_NAME=0
+            
+            uci commit firewall
+            fw4 restart
+            
+            # Allow network stack to settle before interface querying.
+            sleep 1
+            
+            # Retrieve IPv4 address for the wlan0cli interface.
+            CLIENT_IP=$(ifconfig wlan0cli 2>/dev/null | grep 'inet addr' | cut -d: -f2 | awk '{print $1}')
+            
+            if [ -z "$CLIENT_IP" ]; then
+                CLIENT_IP=$(ip -4 addr show wlan0cli 2>/dev/null | grep -oP '(?<=inet\s)\d+(\.\d+){3}' | head -n 1)
+            fi
+
+            LOG "[*] Access Granted"
+            if [ -n "$CLIENT_IP" ]; then
+                LOG "[*] UI: http://${CLIENT_IP}:1471"
+            else
+                LOG "[!] Warning: No Client IP detected"
+            fi
+        fi
+        ;;
+    $DUCKYSCRIPT_USER_DENIED)
+        LOG "Operation cancelled by user."
+        ;;
+    *)
+        exit 0
+        ;;
+esac


### PR DESCRIPTION
### Overview
This utility provides a controlled mechanism for enabling/disabling administrative access (SSH and Web UI) over the Client WiFi (`wlan0cli`) interface. It is designed for developers and auditors who need to manage the Pager via a local network without the need to switch to the Management AP.

### Technical Implementation
* **Targeted Firewall Exception**: Defines a specific `ACCEPT` rule for the `wan` zone targeting TCP ports 22 and 1471.
* **Rule Prioritization**: Implements `uci reorder` to position the management rule at Index 0. This ensures the exception is processed before the system's default rejection rules.
* **Native Integration**: Utilizes the Pager's native `CONFIRMATION_DIALOG` system and `$DUCKYSCRIPT` environment variables for a consistent hardware experience.
* **Network Status Reporting**: Dynamically identifies the IPv4 address assigned to the `wlan0cli` interface and outputs the full management URL to the system log upon activation.
* **Configuration Integrity**: The revocation logic performs a complete deletion of the custom rule from the configuration and restarts the firewall service to restore the factory security state.

### Testing
Verified on hardware. The firewall reloads correctly, and the management interface becomes accessible via the Client IP immediately after confirmation. Access is revoked cleanly when the utility is run a second time.