### PR TITLE
feat: Add ALFA Range Extender for extended WiFi reconnaissance

### DIFF
--- a/library/recon/access_point/alfa-range-extender/README.md
+++ b/library/recon/access_point/alfa-range-extender/README.md
@@ -1,0 +1,260 @@
+# ALFA Range Extender Recon
+
+**Author:** Aitema-GmbH
+**Version:** 2.0
+**Category:** recon/access_point
+**Target:** WiFi Pineapple Pager
+
+## Description
+
+Extends WiFi reconnaissance range using an external ALFA AWUS036ACH adapter with high-gain antenna. This payload configures the adapter for monitor mode and optionally runs automated scanning with airodump-ng.
+
+The ALFA AWUS036ACH provides significantly better range than the Pineapple's built-in radios, making it ideal for extended reconnaissance operations.
+
+## Features
+
+- **Auto Driver Loading**: Automatically loads RTL8812AU kernel module
+- **Monitor Mode Setup**: Configures adapter for passive WiFi scanning
+- **Band Selection**: Choose between 2.4 GHz (range) or 5 GHz (speed)
+- **Automated Scanning**: Optional airodump-ng auto-scan with button stop
+- **Manual Mode**: Prepare adapter for custom scanning
+- **Loot Saving**: Scan results saved to `/root/loot/alfa-recon/`
+
+## Hardware Requirements
+
+### ALFA AWUS036ACH
+- **Chipset**: Realtek RTL8812AU
+- **Bands**: Dual-band 2.4 GHz & 5 GHz
+- **Antenna**: External high-gain (included)
+- **USB**: USB 3.0 (USB 2.0 compatible)
+
+### USB-A Adapter
+The Pineapple Pager has USB-C ports. You need a USB-C to USB-A adapter to connect the ALFA.
+
+## Software Requirements
+
+### RTL8812AU Driver
+
+The driver must be installed before using this payload:
+
+```bash
+# SSH into Pineapple
+ssh root@172.16.52.1
+
+# Update package list
+opkg update
+
+# Install driver (try these in order)
+opkg install kmod-rtl8812au-ct    # Community driver (recommended)
+opkg install kmod-rtl88XXau       # Alternative
+opkg install kmod-rtl8812au       # Another alternative
+```
+
+### aircrack-ng Suite (Optional)
+
+For automated scanning:
+
+```bash
+opkg install aircrack-ng
+```
+
+## Installation
+
+### Option 1: SCP Copy
+
+```bash
+scp -r alfa-range-extender root@172.16.52.1:/root/payloads/recon/access_point/
+ssh root@172.16.52.1 "chmod 755 /root/payloads/recon/access_point/alfa-range-extender/payload.sh"
+```
+
+### Option 2: USB Drive
+
+1. Copy `alfa-range-extender` folder to USB drive
+2. Insert USB into Pineapple
+3. Copy to `/root/payloads/recon/access_point/`
+
+## Usage
+
+### Running the Payload
+
+1. Connect ALFA adapter via USB-A adapter
+2. Navigate to: **Payloads → Recon → Access Point → ALFA Range Extender**
+3. Follow the on-screen prompts
+
+### Workflow
+
+```
+┌─────────────────┐
+│  ALFA Detected  │
+└────────┬────────┘
+         │
+         ▼
+┌─────────────────┐     ┌─────────────────┐
+│ Enable Monitor  │────▶│  Select Band    │
+│      Mode?      │     │ 5 GHz / 2.4 GHz │
+└─────────────────┘     └────────┬────────┘
+                                 │
+                                 ▼
+                        ┌─────────────────┐
+                        │  Auto-Scan?     │
+                        └────────┬────────┘
+                          │           │
+                     Yes  ▼           ▼  No
+              ┌─────────────────┐  ┌─────────────────┐
+              │ airodump-ng     │  │ Manual Mode     │
+              │ (Press B stop)  │  │ Ready message   │
+              └─────────────────┘  └─────────────────┘
+```
+
+### Band Selection
+
+| Band | Pros | Cons |
+|------|------|------|
+| **5 GHz** | Less interference, faster | Shorter range |
+| **2.4 GHz** | Better range, more networks | More crowded |
+
+### Stopping the Scan
+
+When auto-scan is running, press the **B button** on the Pager to stop and save results.
+
+## Output Files
+
+All scan results are saved to `/root/loot/alfa-recon/`:
+
+| File | Description |
+|------|-------------|
+| `scan_YYYYMMDD_HHMMSS-01.csv` | Network list (CSV format) |
+| `scan_YYYYMMDD_HHMMSS-01.kismet.csv` | Kismet XML format |
+| `scan_YYYYMMDD_HHMMSS-01.cap` | Packet capture (PCAP) |
+
+### CSV Format
+
+The CSV file contains:
+- BSSID, First seen, Last seen
+- Channel, Speed, Privacy (encryption)
+- ESSID (network name)
+- Signal strength (dBm)
+
+## LED States
+
+| State | Color | Meaning |
+|-------|-------|---------|
+| SETUP | Magenta | Ready/Idle |
+| ATTACK | Yellow | Working (loading driver, scanning) |
+| FINISH | Green | Success |
+| FAIL | Red | Error |
+
+## Troubleshooting
+
+### "ALFA Adapter not found"
+
+**Causes:**
+1. USB adapter not connected
+2. ALFA not plugged in
+3. Driver not installed
+
+**Solutions:**
+```bash
+# Check USB devices
+lsusb | grep -i realtek
+
+# Check if driver loaded
+lsmod | grep 8812
+
+# Manually load driver
+modprobe 8812au
+```
+
+### "Monitor Mode failed"
+
+**Causes:**
+1. Driver doesn't support monitor mode
+2. Interface busy
+
+**Solutions:**
+```bash
+# Check interface status
+iw dev wlan2 info
+
+# Try manual setup
+ip link set wlan2 down
+iw dev wlan2 set type monitor
+ip link set wlan2 up
+```
+
+### "airodump-ng not found"
+
+**Solution:**
+```bash
+opkg update
+opkg install aircrack-ng
+```
+
+### Wrong Interface (not wlan2)
+
+If your ALFA appears as a different interface:
+
+1. Check available interfaces:
+   ```bash
+   ls /sys/class/net/
+   ```
+
+2. Edit payload.sh and change:
+   ```bash
+   ADAPTER_INTERFACE="wlan3"  # or whatever your interface is
+   ```
+
+## Security & Legal Notes
+
+- **Authorization Required**: Only scan networks you own or have explicit permission to test
+- **Passive Scanning**: Monitor mode is passive but may still be detectable
+- **Local Laws**: WiFi scanning legality varies by jurisdiction
+
+## Technical Details
+
+### Interface Configuration
+
+```bash
+# Set monitor mode
+ip link set wlan2 down
+iw dev wlan2 set type monitor
+ip link set wlan2 up
+
+# Set 5 GHz channel
+iw dev wlan2 set freq 5180  # Channel 36
+
+# Set 2.4 GHz channel
+iw dev wlan2 set freq 2437  # Channel 6
+```
+
+### airodump-ng Options
+
+```bash
+airodump-ng wlan2 \
+  --band abg \                    # All bands (a=5GHz, bg=2.4GHz)
+  -w /root/loot/alfa-recon/scan \ # Output prefix
+  --output-format csv,kismet,pcap # Multiple formats
+```
+
+## Changelog
+
+### Version 2.0
+- Fixed DuckyScript CONFIRMATION_DIALOG handling
+- Removed buggy START_SPINNER/STOP_SPINNER (use LED states)
+- Added proper cleanup trap
+- Added `shopt -s nullglob`
+- English comments and documentation
+- Better error handling
+
+### Version 1.0
+- Initial release
+
+## Credits
+
+- [Hak5](https://hak5.org) - WiFi Pineapple Pager
+- [ALFA Network](https://www.alfa.com.tw/) - AWUS036ACH adapter
+- [aircrack-ng](https://www.aircrack-ng.org/) - WiFi security tools
+
+## License
+
+This payload is released under the [Hak5 License](https://github.com/hak5/wifipineapplepager-payloads/blob/master/LICENSE).

--- a/library/recon/access_point/alfa-range-extender/payload.sh
+++ b/library/recon/access_point/alfa-range-extender/payload.sh
@@ -1,0 +1,243 @@
+#!/bin/bash
+# ============================================================================
+# Title: ALFA Range Extender Recon
+# Description: Extended WiFi scanning with ALFA AWUS036ACH in monitor mode
+# Author: Aitema-GmbH
+# Version: 2.0
+# Category: recon/access_point
+# Target: WiFi Pineapple Pager
+# Hardware: ALFA AWUS036ACH (RTL8812AU)
+# ============================================================================
+#
+# This payload enables an external ALFA AWUS036ACH adapter for extended
+# range WiFi reconnaissance. The adapter's high-gain antenna provides
+# significantly better range than the built-in radio.
+#
+# Requirements:
+#   - ALFA AWUS036ACH connected via USB-A adapter
+#   - RTL8812AU driver installed (kmod-rtl8812au-ct or similar)
+#
+# ============================================================================
+
+shopt -s nullglob
+
+# =========================
+# CONFIGURATION
+# =========================
+ADAPTER_INTERFACE="wlan2"
+LOOT_DIR="/root/loot/alfa-recon"
+LOG_FILE="/tmp/alfa-range-extender.log"
+SCAN_PID=""
+
+# =========================
+# CLEANUP
+# =========================
+cleanup() {
+    # Kill any running scan
+    if [ -n "$SCAN_PID" ]; then
+        kill "$SCAN_PID" 2>/dev/null
+    fi
+    LED SETUP
+}
+trap cleanup EXIT INT TERM
+
+# =========================
+# FUNCTIONS
+# =========================
+
+check_adapter() {
+    if ip link show "$ADAPTER_INTERFACE" > /dev/null 2>&1; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+load_driver() {
+    # Try to load RTL8812AU driver
+    if ! lsmod | grep -q "8812au\|88XXau"; then
+        modprobe 8812au 2>/dev/null || modprobe 88XXau 2>/dev/null
+        sleep 2
+    fi
+}
+
+setup_monitor_mode() {
+    local iface="$1"
+
+    ip link set "$iface" down 2>/dev/null
+    iw dev "$iface" set type monitor 2>/dev/null
+    ip link set "$iface" up 2>/dev/null
+
+    # Verify
+    if iw dev "$iface" info 2>/dev/null | grep -q "type monitor"; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+get_adapter_info() {
+    local iface="$1"
+    local mac=$(cat /sys/class/net/"$iface"/address 2>/dev/null)
+    local driver=$(readlink /sys/class/net/"$iface"/device/driver 2>/dev/null | xargs basename 2>/dev/null)
+    echo "MAC: $mac | Driver: $driver"
+}
+
+# =========================
+# MAIN
+# =========================
+
+# Create loot directory
+mkdir -p "$LOOT_DIR"
+
+# Start logging
+echo "=== ALFA Range Extender started: $(date) ===" >> "$LOG_FILE"
+
+LED SETUP
+LOG cyan "=========================================="
+LOG cyan "  ALFA RANGE EXTENDER"
+LOG cyan "=========================================="
+LOG ""
+LOG "Initializing ALFA AWUS036ACH..."
+LOG ""
+
+# Step 1: Load driver
+LED ATTACK
+LOG "Loading RTL8812AU driver..."
+load_driver
+sleep 1
+
+# Step 2: Check adapter
+if ! check_adapter; then
+    LED FAIL
+    ERROR_DIALOG "ALFA Adapter not found!\n\nPlease check:\n- USB-A adapter connected?\n- ALFA AWUS036ACH plugged in?\n- RTL8812AU driver installed?"
+    echo "ERROR: Adapter not found" >> "$LOG_FILE"
+    exit 1
+fi
+
+# Show adapter info
+ADAPTER_INFO=$(get_adapter_info "$ADAPTER_INTERFACE")
+LOG green "Adapter detected!"
+LOG "$ADAPTER_INFO"
+LOG ""
+
+# Step 3: Confirm monitor mode activation
+RESP=$(CONFIRMATION_DIALOG "Enable Monitor Mode\nfor extended recon?")
+case $? in
+    $DUCKYSCRIPT_REJECTED|$DUCKYSCRIPT_CANCELLED)
+        LOG yellow "Cancelled by user"
+        exit 0
+        ;;
+    $DUCKYSCRIPT_ERROR)
+        LOG red "Dialog error"
+        exit 1
+        ;;
+esac
+
+case "$RESP" in
+    "$DUCKYSCRIPT_USER_DENIED")
+        LOG yellow "User declined"
+        ALERT "Setup cancelled"
+        exit 0
+        ;;
+esac
+
+# Step 4: Enable monitor mode
+LED ATTACK
+LOG "Enabling Monitor Mode..."
+
+if ! setup_monitor_mode "$ADAPTER_INTERFACE"; then
+    LED FAIL
+    ERROR_DIALOG "Monitor Mode failed!\n\nPossible causes:\n- Driver issue\n- Interface busy"
+    exit 1
+fi
+
+LOG green "Monitor Mode active on $ADAPTER_INTERFACE"
+LOG ""
+
+# Step 5: Select band
+RESP=$(CONFIRMATION_DIALOG "Select band:\n\n[Yes] = 5 GHz (faster)\n[No] = 2.4 GHz (range)")
+case $? in
+    $DUCKYSCRIPT_REJECTED|$DUCKYSCRIPT_CANCELLED)
+        LOG yellow "Cancelled"
+        exit 0
+        ;;
+esac
+
+case "$RESP" in
+    "$DUCKYSCRIPT_USER_CONFIRMED")
+        BAND="5GHz"
+        CHANNELS="36,40,44,48,52,56,60,64,100,104,108,112,116,120,124,128,132,136,140,149,153,157,161,165"
+        iw dev "$ADAPTER_INTERFACE" set freq 5180 2>/dev/null  # Channel 36
+        ;;
+    *)
+        BAND="2.4GHz"
+        CHANNELS="1,2,3,4,5,6,7,8,9,10,11,12,13"
+        iw dev "$ADAPTER_INTERFACE" set freq 2437 2>/dev/null  # Channel 6
+        ;;
+esac
+
+LOG "Band: $BAND selected"
+LOG ""
+
+# Step 6: Select scan mode
+RESP=$(CONFIRMATION_DIALOG "Start auto-scan?\n\n[Yes] = airodump-ng auto\n[No] = Manual setup only")
+case $? in
+    $DUCKYSCRIPT_REJECTED|$DUCKYSCRIPT_CANCELLED)
+        LOG yellow "Cancelled"
+        exit 0
+        ;;
+esac
+
+case "$RESP" in
+    "$DUCKYSCRIPT_USER_CONFIRMED")
+        # Auto-scan mode
+        SCAN_FILE="$LOOT_DIR/scan_$(date +%Y%m%d_%H%M%S)"
+        LOG cyan "Starting scan..."
+        LOG "Output: $SCAN_FILE"
+        LOG ""
+        LOG yellow "Press B button to stop"
+
+        # Check if airodump-ng is available
+        if ! command -v airodump-ng > /dev/null 2>&1; then
+            LED FAIL
+            ERROR_DIALOG "airodump-ng not found!\n\nInstall with:\nopkg install aircrack-ng"
+            exit 1
+        fi
+
+        LED ATTACK
+
+        # Start airodump-ng in background
+        airodump-ng "$ADAPTER_INTERFACE" --band abg -w "$SCAN_FILE" --output-format csv,kismet,pcap &
+        SCAN_PID=$!
+
+        # Wait for button press
+        WAIT_FOR_BUTTON_PRESS B
+
+        # Stop scan
+        kill "$SCAN_PID" 2>/dev/null
+        SCAN_PID=""
+
+        LOG green "Scan stopped"
+        LOG ""
+        LOG "Results saved to:"
+        LOG "$SCAN_FILE.*"
+
+        LED FINISH
+        VIBRATE
+
+        ALERT "Scan Complete!\n\nResults saved:\n$SCAN_FILE.*\n\nFiles:\n- .csv (networks)\n- .kismet (XML)\n- .pcap (packets)"
+        ;;
+    *)
+        # Manual mode
+        LED FINISH
+
+        ALERT "ALFA Ready!\n\nInterface: $ADAPTER_INTERFACE\nMode: Monitor\nBand: $BAND\n\nManual scan:\nairodump-ng $ADAPTER_INTERFACE"
+        ;;
+esac
+
+# Log completion
+echo "=== Session ended: $(date) ===" >> "$LOG_FILE"
+LOG green "ALFA Range Extender session complete"
+
+exit 0


### PR DESCRIPTION
## Summary

Adds a new recon payload for using an external ALFA AWUS036ACH adapter with the WiFi Pineapple Pager. This enables significantly extended range WiFi reconnaissance using the adapter's high-gain antenna.

### New Payload

**Recon Payload: `recon/access_point/alfa-range-extender/`**
- Extends WiFi reconnaissance range with external ALFA adapter
- Auto-loads RTL8812AU kernel module
- Configures monitor mode with verification
- Dual-band support (2.4 GHz / 5 GHz)
- Optional automated airodump-ng scanning

### Features

- ✅ **Auto Driver Loading**: Attempts to load RTL8812AU kernel module
- ✅ **Monitor Mode Setup**: Configures adapter with verification
- ✅ **Band Selection**: User chooses 2.4 GHz (range) or 5 GHz (speed)
- ✅ **Automated Scanning**: airodump-ng with B button stop
- ✅ **Manual Mode**: Just setup, user does custom scan
- ✅ **Proper DuckyScript 3.0**: Correct CONFIRMATION_DIALOG handling
- ✅ **Cleanup Trap**: Kills scan process on exit
- ✅ **LED Feedback**: SETUP/ATTACK/FINISH/FAIL states
- ✅ **Loot Saving**: Results to `/root/loot/alfa-recon/`

### Hardware

**ALFA AWUS036ACH**
- Chipset: Realtek RTL8812AU
- Bands: 2.4 GHz & 5 GHz
- Antenna: External high-gain
- USB: 3.0 (2.0 compatible)

Requires USB-C to USB-A adapter for Pineapple Pager.

### Files Added

```
library/recon/access_point/alfa-range-extender/
├── payload.sh    # Main payload
└── README.md     # Documentation
```

### DuckyScript Compliance

- ✅ `shopt -s nullglob`
- ✅ `trap cleanup EXIT INT TERM`
- ✅ Correct `$DUCKYSCRIPT_*` constant handling
- ✅ No buggy START_SPINNER/STOP_SPINNER (uses LED states)
- ✅ Proper error dialogs

### Workflow

```
ALFA Detected → Monitor Mode? → Select Band → Auto-Scan?
                                                  │
                               ┌──────────────────┴──────────────────┐
                               │                                     │
                          airodump-ng                          Manual Mode
                        (B button stops)                    (user does scan)
```

### Documentation

Comprehensive README.md with:
- Hardware requirements
- Driver installation guide
- Usage instructions with workflow diagram
- Output file descriptions
- Troubleshooting guide
- Technical details

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)