### PR TITLE
feat: add wan_verifier payload for OpSec verification

### DIFF
--- a/library/user/general/wan_verifier/README.md
+++ b/library/user/general/wan_verifier/README.md
@@ -1,0 +1,63 @@
+# WAN Verifier
+
+**WAN Verifier** is a lightweight utility for the WiFi Pineapple Pager. It allows you to quickly verify your external network footprint and compare it against a known baseline.
+
+## Features
+
+*   **Instant Verification:** Displays your Public IP, ISP, and geographic location.
+*   **Baseline Comparison:** Checks if your current IP matches a stored "Baseline" IP (e.g., your home or lab connection).
+*   **Safety Status:** Detects if you are exposed on a known "Home" network.
+*   **API Redundancy:** Automatically falls back to secondary providers if the primary API is unreachable.
+*   **Caching:** Caches results for 60 seconds to save data and battery on repeated checks.
+*   **Developer API:** Can be called by other payloads to perform silent checks.
+
+## Usage
+
+1.  Connect the WiFi Pineapple to a network.
+2.  Navigate to **WAN Verifier** in the payload menu.
+3.  Launch the payload.
+4.  Review your status:
+    *   **IP:** Your visible public IP.
+    *   **ISP:** The provider carrying your traffic (e.g., "Mullvad", "Comcast").
+    *   **Status:** 
+        *   `NO MATCH`: IP differs from your stored baseline.
+        *   `MATCH`: You are currently on your stored baseline IP.
+
+## Controls
+
+*   **[A] Refresh:** Force a new lookup (bypasses cache).
+*   **[<] Save as Baseline:** Save the current IP as your known baseline.
+*   **[B] Exit:** Quit the application.
+
+## Developer API
+
+Other payloads can use `WAN Verifier` as a library to perform checks before running operations.
+
+### Modes
+*   **Check Mode:** `./payload.sh --check`
+    *   Output: `NO_MATCH: <IP>` or `MATCH: <IP>`
+    *   Exit Code: `0` (No Match), `1` (Match), `2` (No Internet), `3` (API Error)
+*   **Silent Mode:** `./payload.sh --silent`
+    *   Output: None
+    *   Exit Code: Same as above.
+
+### Example Usage
+```bash
+# Example: Only run if we are NOT on the baseline network
+if /path/to/wan_verifier/payload.sh --silent; then
+    LOG "Identity is masked (No Match). Proceeding..."
+    # ... logic ...
+else
+    LOG "ABORT: Matches Baseline or No Connection!"
+    exit 1
+fi
+```
+
+## Requirements
+
+*   Internet connection on the WiFi Pineapple.
+*   `curl` and `jq` installed on the system.
+
+## Configuration
+
+The script uses **`http://ip-api.com/json`** as the primary provider and **`http://ipinfo.io/json`** as a fallback. You can modify these variables at the top of `payload.sh` if you prefer different services.

--- a/library/user/general/wan_verifier/payload.sh
+++ b/library/user/general/wan_verifier/payload.sh
@@ -1,0 +1,232 @@
+#!/bin/bash
+# Title: WAN Verifier
+# Description: Verifies WAN IP and ISP to ensure anonymity. Alerts if on a known 'Baseline' IP.
+# Author: klownmovez
+# Version: 0.1
+# Category: General
+
+# ====================================================================
+# Configuration
+# ====================================================================
+API_URL_PRIMARY="http://ip-api.com/json"
+API_URL_BACKUP="http://ipinfo.io/json"
+TIMEOUT=5
+CACHE_FILE="/tmp/wan_guard_cache.json"
+CACHE_TTL=60 # Seconds
+SAVED_IP_FILE="/root/wan_verifier_saved_ip"
+
+# Global Variables for State
+IP=""
+ISP=""
+COUNTRY=""
+REGION=""
+ORG=""
+STATUS_COLOR="YELLOW"
+
+# ====================================================================
+# Helper Functions
+# ====================================================================
+
+# Checks if a file is older than X seconds
+is_cache_valid() {
+    local file=$1
+    local ttl=$2
+    if [ -f "$file" ]; then
+        local now=$(date +%s)
+        local mod=$(date -r "$file" +%s)
+        local age=$((now - mod))
+        if [ $age -lt $ttl ]; then
+            return 0 # Valid
+        fi
+    fi
+    return 1 # Invalid
+}
+
+# Saves the current IP as "Baseline" to compare against
+save_current_ip() {
+    local ip=$1
+    echo "$ip" > "$SAVED_IP_FILE"
+}
+
+# Core Logic: Fetch and Parse
+fetch_data() {
+    local silent=$1
+    
+    # Check Internet Connectivity
+    if ! ping -c 1 -W 2 8.8.8.8 > /dev/null 2>&1; then
+        [ -z "$silent" ] && LOG "ERROR: No Internet Connection"
+        return 2 # No Internet
+    fi
+
+    local data=""
+    if is_cache_valid "$CACHE_FILE" "$CACHE_TTL"; then
+        [ -z "$silent" ] && LOG "Loading from cache..."
+        data=$(cat "$CACHE_FILE")
+    else
+        [ -z "$silent" ] && LOG "Fetching WAN details..."
+        
+        # Try Primary API
+        if data=$(curl -s -m "$TIMEOUT" "$API_URL_PRIMARY") && [ -n "$data" ]; then
+            # Primary Success
+            echo "$data" > "$CACHE_FILE"
+        else
+            # Primary Failed
+            [ -z "$silent" ] && LOG "Primary API failed. Trying backup..."
+            
+            # Try Backup
+            if data=$(curl -s -m "$TIMEOUT" "$API_URL_BACKUP") && [ -n "$data" ]; then
+                # Backup Success
+                echo "$data" > "$CACHE_FILE"
+            else
+                # Both Failed
+                [ -z "$silent" ] && LOG "ERROR: All APIs Failed"
+                return 3 # API Error
+            fi
+        fi
+    fi
+
+    # Parse (Handle multiple API formats)
+    # ip-api: query, isp, countryCode, regionName
+    # ipinfo.io: ip, org, country, region
+    IP=$(echo "$data" | jq -r '.query // .ip // "Unknown"')
+    ISP=$(echo "$data" | jq -r '.isp // .org // "Unknown"')
+    COUNTRY=$(echo "$data" | jq -r '.countryCode // .country // "Unknown"')
+    REGION=$(echo "$data" | jq -r '.regionName // .region // "Unknown"')
+    
+    return 0
+}
+
+# Core Logic: Evaluate Identity
+evaluate_identity() {
+    local saved_ip=""
+    if [ -f "$SAVED_IP_FILE" ]; then
+        saved_ip=$(cat "$SAVED_IP_FILE")
+    fi
+
+    if [ -n "$saved_ip" ] && [ "$IP" == "$saved_ip" ]; then
+        STATUS_COLOR="RED"
+        return 1 # MATCH
+    else
+        STATUS_COLOR="GREEN"
+        return 0 # NO MATCH
+    fi
+}
+
+# ====================================================================
+# Execution Mode Handler
+# ====================================================================
+
+# Check if running in "Check Mode" (called by another script)
+if [ "$1" == "--check" ] || [ "$1" == "--silent" ]; then
+    SILENT_MODE=""
+    [ "$1" == "--silent" ] && SILENT_MODE="yes"
+    
+    fetch_data "$SILENT_MODE"
+    FETCH_RES=$?
+    
+    if [ $FETCH_RES -ne 0 ]; then
+        exit $FETCH_RES
+    fi
+    
+    evaluate_identity
+    IDENTITY_RES=$?
+    
+    if [ -z "$SILENT_MODE" ]; then
+        if [ $IDENTITY_RES -eq 1 ]; then
+            echo "MATCH: $IP"
+        else
+            echo "NO_MATCH: $IP"
+        fi
+    fi
+    
+    exit $IDENTITY_RES
+fi
+
+# ====================================================================
+# Interactive User Interface (Default Mode)
+# ====================================================================
+
+LOG "Initializing WAN Verifier..."
+
+# Initial Fetch
+fetch_data
+RES=$?
+if [ $RES -ne 0 ]; then
+    ALERT "Initialization Failed\nCheck Internet/API"
+    exit 1
+fi
+
+evaluate_identity
+
+while true; do
+    # Calculate Cache Age safely
+    CACHE_AGE="0"
+    if [ -f "$CACHE_FILE" ]; then
+        # Try to get file modification time. 
+        # Busybox date -r might behave differently, so we suppress errors.
+        FILE_TIME=$(date -r "$CACHE_FILE" +%s 2>/dev/null)
+        if [ -n "$FILE_TIME" ]; then
+            NOW=$(date +%s)
+            CACHE_AGE=$((NOW - FILE_TIME))
+        fi
+    fi
+
+    # 1. Display the "Dashboard"
+    LOG ""
+    LOG "=== WAN VERIFIER ==="
+    LOG "IP:  $IP"
+    LOG "ISP: $ISP"
+    LOG "Loc: $REGION, $COUNTRY"
+    LOG "Updated: ${CACHE_AGE}s ago"
+    LOG "------------------"
+    
+    # Status Line
+    if [ "$STATUS_COLOR" == "RED" ]; then
+        LOG "STATUS: [ MATCH ]"
+        LOG "Matches Baseline IP!"
+    else
+        LOG "STATUS: [ NO MATCH ]"
+        LOG "Differs from Baseline."
+    fi
+
+    LOG ""
+    LOG "[A] Refresh Data"
+    LOG "[<] Save as Baseline"
+    LOG "[B] Exit"
+
+    # 2. Wait for user interaction
+    BUTTON=$(WAIT_FOR_INPUT)
+    
+    case "$BUTTON" in
+        "A"|"ENTER")
+            # Refresh Action
+            LOG "Refreshing..."
+            rm -f "$CACHE_FILE"
+            
+            fetch_data
+            if [ $? -ne 0 ]; then
+                LOG "ERROR: Refresh failed."
+                ALERT "Refresh Failed\nCheck Internet."
+            else
+                evaluate_identity
+            fi
+            ;;
+            
+        "LEFT")
+            # Save Action
+            save_current_ip "$IP"
+            LOG "Saved $IP as Baseline."
+            STATUS_COLOR="RED"
+            ;;
+            
+        "B")
+            # Exit Action
+            LOG "Exiting..."
+            exit 0
+            ;;
+            
+        *)
+            # Ignore other buttons
+            ;;
+    esac
+done


### PR DESCRIPTION
Introduces utility to verify public network identity and ensure active VPN/Proxy masking. Key features include:
- Dual API Redundancy: Seamlessly falls back from ip-api.com to ipinfo.io.
- Baseline Comparison: Allows users to save a "Baseline IP" and detects identity matches (e.g., marking home/lab networks).
- Interactive Dashboard: Native pager UI driven by physical buttons with real-time cache age timestamps.
- Developer API: Supports --check and --silent modes for integration  into other third-party payloads.
- Resource Efficient: Implements 60s local caching and strict timeouts to minimize data usage and battery drain.

Includes payload.sh and comprehensive README.md documentation.