### PR TITLE
Windows Friendly Handshakes

### DIFF
--- a/library/user/general/WindowsFriendlyHandshakes/payload.sh
+++ b/library/user/general/WindowsFriendlyHandshakes/payload.sh
@@ -26,4 +26,3 @@ ALERT "Operation Complete"
 LOG " "
 LOG "OPERATION COMPLETE."
 LOG "To see the full results go to $INFOPATH/$FILENAME"
-root@skinny:~/payloads/user/Skinny_Tools/WindowsFriendlyHandshakes#


### PR DESCRIPTION
Payload used to make Handshake files Windows friendly. Gets rid of colons from the filename. Files must be stored in /root/loot/handshakes/