### PR TITLE
Exfiltration Payload: FirewallSwitcher

### DIFF
--- a/library/user/exfiltration/FirewallSwitcher/payload.sh
+++ b/library/user/exfiltration/FirewallSwitcher/payload.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+# Title:                FirewallSwitcher
+# Description:          Toggles the firewall on and off for SSH/Virtual Pager access in Client Mode
+# Note:                 Firewall automatically re-enables on reboot
+# Author:               r3dfish
+# Version:              1.0
+
+# Options
+SWITCHER_STATUS="Disable"
+
+# Check to see if the firewall is running
+LOG "Checking if Firewall is enabled"
+if nft list tables | grep fw4; then
+	LOG "Firewall is running!"
+else
+	LOG "Firewall is not running."
+	SWITCHER_STATUS="Enable"
+fi
+
+LOG "Launching switcher dialog..."
+
+resp=$(CONFIRMATION_DIALOG $SWITCHER_STATUS " Firewall?")
+case $? in
+    $DUCKYSCRIPT_REJECTED)
+        LOG "Dialog rejected"
+        exit 1
+        ;;
+    $DUCKYSCRIPT_ERROR)
+        LOG "An error occurred"
+        exit 1
+        ;;
+esac
+
+case "$resp" in
+    $DUCKYSCRIPT_USER_CONFIRMED)
+        LOG "User selected yes"
+	if [[ $SWITCHER_STATUS == "Enable" ]]; then
+		fw4 start
+	else
+		fw4 stop
+	fi
+        ;;
+    $DUCKYSCRIPT_USER_DENIED)
+        LOG "User selected no"
+	LOG "No action taken"
+        ;;
+    *)
+        LOG "Unknown response: $resp"
+        ;;
+esac
+
+if nft list tables | grep fw4; then
+	LOG "Firewall is running!"
+else
+	LOG "Firewall is not running."
+fi


### PR DESCRIPTION
Enable/Disable firewall from a payload.  This is used to be able to SSH/Virtual Pager when in client mode.  Disabling the firewall does not survive a reboot, it is automatically re-enabled on reboot.  Running the payload repeatedly will allow you to enable/disable the firewall as many times as you want without having to connect to the pager to enable/disable the firewall.