### PR TITLE
Add Handshake Sanitiser utility for loot management

### DIFF
--- a/library/user/general/handshake_sanitiser/README.md
+++ b/library/user/general/handshake_sanitiser/README.md
@@ -1,0 +1,30 @@
+# Handshake Sanitiser
+
+**Author:** PanicAcid  
+**Version:** 1.0  
+**Target:** Handshake Loot Management (`~/loot/handshakes`)
+
+---
+
+## The Problem
+If you leave a Pineapple running for any decent amount of time, your handshake folder becomes a nightmare. You end up with hundreds of duplicate captures for the same network, and because the filenames contain colons (`:`), Windows refuses to touch them. It makes managing your loot a total chore.
+
+## The Solution
+**Handshake Sanitiser** is a straightforward utility to get your loot folder under control. It handles the heavy lifting of sorting through your captures and making sure you only keep the stuff that actually matters.
+
+### Features
+* **Smart Deduplication**: Scans your MAC address pairings and keeps only the absolute newest capture for each target. 
+* **Quality Control**: Got a full handshake? The script can automatically nuke the partial ones for that same network, so you aren't wasting time on inferior captures.
+* **Windows Normalisation**: Swaps those illegal colons (`:`) for hyphens (`-`). You can finally drag-and-drop your loot folder straight onto a Windows machine without it throwing a fit.
+* **Non-Destructive**: It always keeps the best available version of a handshake. If you only have a partial, it stays safe until you manage to snag a full one.
+
+## Usage
+1. Run **Handshake Sanitiser** from the User Payloads menu.
+2. Follow the prompts on the screen to choose your cleaning method:
+   - **Deduplicate?** (Removes older identical captures).
+   - **Purge Partials?** (Removes partials if you've already got a full one).
+   - **Rename for Windows?** (Fixes the colon character issue).
+3. Check the system log for a summary of how much junk was cleared out.
+
+---
+*Surgical loot organisation for the WiFi Pineapple Pager.*

--- a/library/user/general/handshake_sanitiser/payload.sh
+++ b/library/user/general/handshake_sanitiser/payload.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+# Title: Handshake Sanitiser
+# Author: PanicAcid
+# Description: Advanced loot management with Full vs Partial quality control.
+# Version: 1.0
+
+HANDSHAKE_DIR="/root/loot/handshakes"
+
+# 1. Directory Validation
+if [ ! -d "$HANDSHAKE_DIR" ]; then
+    LOG "[!] Error: Handshake directory not found."
+    exit 1
+fi
+
+# 2. User Interaction Sequence
+DO_DEDUPE=$(CONFIRMATION_DIALOG "Deduplicate captures? (Keeps newest of each type)")
+DO_PURGE_PARTIAL=$(CONFIRMATION_DIALOG "Purge Partials if a Full exists for that target?")
+DO_RENAME=$(CONFIRMATION_DIALOG "Rename for Windows? (Replaces : with -)")
+
+if [ "$DO_DEDUPE" == "0" ] && [ "$DO_PURGE_PARTIAL" == "0" ] && [ "$DO_RENAME" == "0" ]; then
+    LOG "No actions selected. Exiting."
+    exit 0
+fi
+
+cd "$HANDSHAKE_DIR" || exit 1
+
+# 3. Execution: Deduplication (Standard newest-of-each-type logic)
+if [ "$DO_DEDUPE" == "1" ]; then
+    LOG "Deduplicating handshakes..."
+    unique_events=$(ls | sed 's/^[0-9]*_//' | cut -d'.' -f1 | sort -u)
+    d_count=0
+    for event in $unique_events; do
+        timestamps=$(ls | grep -F "_${event}." | cut -d'_' -f1 | sort -rn -u)
+        latest_ts=$(echo "$timestamps" | head -n 1)
+        old_timestamps=$(echo "$timestamps" | tail -n +2)
+        for old_ts in $old_timestamps; do
+            rm -f ${old_ts}_${event}.* && ((d_count++))
+        done
+    done
+    LOG "[*] Deduplication complete. $d_count files removed."
+fi
+
+# 4. Execution: Quality Purge (Nuke Partials if Full exists)
+if [ "$DO_PURGE_PARTIAL" == "1" ]; then
+    LOG "Cleaning up redundant partials..."
+    p_count=0
+    # Find all unique BSSID_Client pairings (ignoring the suffix)
+    pairings=$(ls | cut -d'_' -f2-3 | sort -u)
+    
+    for pair in $pairings; do
+        # Check if we have at least one FULL handshake for this pair
+        if ls *_${pair}_handshake.pcap >/dev/null 2>&1; then
+            # If yes, delete any PARTIAL handshakes for this pair
+            if ls *_${pair}_handshake_partial.* >/dev/null 2>&1; then
+                rm -f *_${pair}_handshake_partial.*
+                ((p_count++))
+            fi
+        fi
+    done
+    LOG "[*] Quality Purge complete. $p_count redundant partials removed."
+fi
+
+# 5. Execution: Windows Normalisation
+if [ "$DO_RENAME" == "1" ]; then
+    LOG "Applying Windows naming standards..."
+    r_count=0
+    for file in *:* ; do
+        [ -e "$file" ] || continue
+        new_name=$(echo "$file" | tr ':' '-')
+        mv "$file" "$new_name"
+        ((r_count++))
+    done
+    LOG "[*] Normalisation complete. $r_count files updated."
+fi
+
+LOG "[*] Sanitiser finished. Loot is high-quality and clean."


### PR DESCRIPTION
### Overview
This PR introduces the Handshake Sanitiser, a maintenance utility designed to manage the accumulation of redundant handshake captures and resolve filesystem compatibility issues with Windows.

### The Problem
Automated capture tools often generate dozens of duplicate .pcap and .22000 files for the same target BSSID/Client pairing. Furthermore, the standard naming convention uses colons ( : ), which are illegal characters on Windows filesystems, making loot export and analysis difficult for many users.

### Key Logic & Features
* **Suffix-Aware Deduplication**: The script identifies unique "events" by parsing MAC addresses and handshake types. It preserves the single newest file pair (.pcap/.22000) while purging historical duplicates.
* **Quality-Based Purging**: An optional logic gate allows users to purge 'partial' handshakes if a 'full' handshake for the same target is detected.
* **Windows Normalisation**: Iteratively replaces colons with hyphens across the directory to ensure OS compatibility.
* **Order Independence**: The utility is designed to handle files correctly regardless of whether they have already been renamed or deduplicated in previous runs.

### Testing Results
Successfully tested on hardware using a "real-world" loot directory containing 410 files.
* **Result**: Reduced clutter to 29 unique, high-quality captures.
* **Integrity**: Verified that the newest full handshakes were preserved and all colons were correctly sanitised for Windows export.