### PR TITLE
Add gps picker payload

### DIFF
--- a/library/user/gps_dev_picker/payload.sh
+++ b/library/user/gps_dev_picker/payload.sh
@@ -8,7 +8,7 @@
 LED R
 
 # Use TEXT_PICKER to enter any device (no validation)
-DEVICE=$(TEXT_PICKER "Enter device (e.g. ttyACM0)" "ttyACM0") || exit 0
+DEVICE=$(TEXT_PICKER "Enter device." "ttyACM0") || exit 0
 
 # Add /dev/ prefix if not already present
 case $DEVICE in


### PR DESCRIPTION
Allows user to select any gps device instead of just /dev/ttyACM2