### PR TITLE
Bump version to 1.4.1 and update dependencies

### DIFF
--- a/library/user/general/UpdateRingtones/payload.sh
+++ b/library/user/general/UpdateRingtones/payload.sh
@@ -2,7 +2,7 @@
 # Title: Update Ringtones
 # Description: Downloads and syncs all ringtones from github.
 # Author: cococode
-# Version: 1.4
+# Version: 1.4.1
 
 # === CONFIGURATION ===
 GH_ORG="hak5"
@@ -36,7 +36,7 @@ setup() {
     if ! which unzip > /dev/null; then
         LOG "Installing unzip..."
         opkg update
-        opkg install unzip
+        opkg install unzip diffutils
     fi
 }
 


### PR DESCRIPTION
This payload requires the 'diff' utility to determine if changes have been made, since last update. 

 As openwrt is missing the 'diff' utility, Updated version to 1.4.1 and added 'diffutils' to dependencies.

