### PR TITLE
Add Payload Manager payload

### DIFF
--- a/library/user/general/PayloadManager/README.md
+++ b/library/user/general/PayloadManager/README.md
@@ -8,41 +8,68 @@ A comprehensive payload management tool for the WiFi Pineapple Pager. Browse, in
 - **Check for Updates** - Get a summary of available updates with the choice of interactive review or batch update mode
 - **Install/Uninstall** - Add new payloads from the repository or remove existing ones from your device
 - **Enable/Disable** - Temporarily disable payloads without deleting them - useful for troubleshooting or freeing up menu space
+- **Persistent Settings** - Configure default behaviors that persist across firmware upgrades
+
+## First Run Setup
+
+On first launch, Payload Manager walks you through initial configuration:
+
+1. **Update Mode** - Choose how updates are handled (ask each time, always interactive, or always batch)
+2. **Repository** - Use the official Hak5 repository or specify a custom fork
+3. **Display Options** - Whether to show local-only payloads in browse view
+
+These settings are saved persistently and can be changed later from the Settings menu.
 
 ## Menu Options
 
-| Option             | Description                                                              | Network  |
-|--------------------|--------------------------------------------------------------------------|----------|
-| Browse & Compare   | Navigate payloads by category, view details and metadata, install or update | Required |
-| Check for Updates  | Summary of available updates with batch or interactive update mode       | Required |
-| Manage Installed   | List all enabled payloads, disable or uninstall them                     | Offline  |
-| Manage Disabled    | List all disabled payloads, re-enable or uninstall them                  | Offline  |
+| Option            | Description                                                    |
+|-------------------|----------------------------------------------------------------|
+| Browse & Compare  | Navigate payloads by category, view details, install or update |
+| Check for Updates | Summary of available updates with batch or interactive mode    |
+| Manage Installed  | List all enabled payloads, disable or uninstall them           |
+| Manage Disabled   | List all disabled payloads, re-enable or uninstall them        |
+| Settings          | Configure update behavior, repository, and display options     |
 
 ## Status Indicators
 
 When browsing payloads, status icons indicate their current state:
 
-| Icon    | Meaning                                              |
-|---------|------------------------------------------------------|
-| `[NEW]` | Available on GitHub but not installed locally        |
-| `[OK]`  | Installed and matches the latest GitHub version      |
-| `[UPD]` | Installed but a newer version is available           |
-| `[DIS]` | Installed but currently disabled                     |
+| Icon    | Meaning                                               |
+|---------|-------------------------------------------------------|
+| `[NEW]` | Available on GitHub but not installed locally         |
+| `[OK]`  | Installed and matches the latest GitHub version       |
+| `[UPD]` | Installed but a newer version is available            |
+| `[DIS]` | Installed but currently disabled                      |
 | `[LOC]` | Exists locally but not found in the GitHub repository |
+
+## Settings
+
+Access settings from the main menu to configure:
+
+| Setting            | Description                                              |
+|--------------------|----------------------------------------------------------|
+| Update mode        | `ask` (prompt each time), `interactive`, or `batch`      |
+| Repository         | Use official Hak5 repo or specify a custom `user/repo`   |
+| Branch             | Which branch to pull from (default: `master`)            |
+| Show local payloads | Whether to display `[LOC]` payloads when browsing       |
+
+Settings persist across reboots and firmware upgrades using the Pager's config system.
 
 ## Update Workflow
 
-When checking for updates, you'll see a summary of how many payloads are up to date, how many updates are available, and how many new payloads exist. From there you can choose:
+When checking for updates, you'll see a summary of how many payloads are up to date, how many updates are available, and how many new payloads exist.
 
-1. **Interactive Mode** - Review each new/updated payload one by one and decide whether to install or skip
-2. **Batch Mode** - Automatically install all new payloads and apply all updates at once
-3. **Skip** - Cancel and return to the main menu
+Based on your **Update mode** setting:
+
+- **Ask** (default) - Prompts whether to review individually or update all
+- **Interactive** - Automatically enters interactive mode to review each payload
+- **Batch** - Automatically installs all new payloads and applies all updates
 
 After updates complete, you'll see a summary of what was installed, updated, or skipped.
 
 ## How Disable Works
 
-Disabling a payload renames `payload.sh` to `payload.sh.disabled`. This hides the payload from the pager's discovery mechanism since it looks for files named `payload.sh`. The payload directory and all its files remain intact, so you can re-enable it at any time by simply renaming the file back.
+Disabling a payload renames `payload.sh` to `payload.sh.disabled`. This hides the payload from the pager's discovery mechanism since it looks for files named `payload.sh`. The payload directory and all its files remain intact, so you can re-enable it at any time.
 
 This is useful when you want to:
 
@@ -61,4 +88,7 @@ If the Payload Manager itself has an update available, the update is queued and 
 
 ## Source Repository
 
-Payloads are pulled from the official [Hak5 WiFi Pineapple Pager Payloads](https://github.com/hak5/wifipineapplepager-payloads) repository.
+By default, payloads are pulled from the official Hak5 repository:
+<https://github.com/hak5/wifipineapplepager-payloads>
+
+You can configure a custom repository in Settings to use your own fork or a community repository.

--- a/library/user/general/PayloadManager/payload.sh
+++ b/library/user/general/PayloadManager/payload.sh
@@ -5,10 +5,280 @@
 # Version: 1.0
 
 # === CONFIGURATION ===
+CONFIG_NAME="PayloadManager"
+
+# Default values (can be overridden by user settings)
 GH_ORG="hak5"
 GH_REPO="wifipineapplepager-payloads"
 GH_BRANCH="master"
-ZIP_URL="https://github.com/$GH_ORG/$GH_REPO/archive/refs/heads/$GH_BRANCH.zip"
+
+# Settings (loaded from persistent config)
+SETTING_DEFAULT_MODE="ask"      # ask, interactive, batch
+SETTING_CUSTOM_REPO=""          # user/repo format, empty = use default
+SETTING_CUSTOM_BRANCH=""        # branch name, empty = use default
+SETTING_SHOW_LOCAL="true"       # show [LOC] payloads in browse
+
+# === SETTINGS FUNCTIONS ===
+
+load_settings() {
+    # Load each setting, using default if not set
+    local val=""
+
+    val=$(PAYLOAD_GET_CONFIG "$CONFIG_NAME" default_mode 2>/dev/null) && [ -n "$val" ] && SETTING_DEFAULT_MODE="$val"
+    val=$(PAYLOAD_GET_CONFIG "$CONFIG_NAME" custom_repo 2>/dev/null) && [ -n "$val" ] && SETTING_CUSTOM_REPO="$val"
+    val=$(PAYLOAD_GET_CONFIG "$CONFIG_NAME" custom_branch 2>/dev/null) && [ -n "$val" ] && SETTING_CUSTOM_BRANCH="$val"
+    val=$(PAYLOAD_GET_CONFIG "$CONFIG_NAME" show_local 2>/dev/null) && [ -n "$val" ] && SETTING_SHOW_LOCAL="$val"
+
+    # Apply custom repo/branch if set
+    if [ -n "$SETTING_CUSTOM_REPO" ]; then
+        GH_ORG=$(echo "$SETTING_CUSTOM_REPO" | cut -d'/' -f1)
+        GH_REPO=$(echo "$SETTING_CUSTOM_REPO" | cut -d'/' -f2)
+    fi
+    if [ -n "$SETTING_CUSTOM_BRANCH" ]; then
+        GH_BRANCH="$SETTING_CUSTOM_BRANCH"
+    fi
+}
+
+save_setting() {
+    local key="$1"
+    local value="$2"
+    PAYLOAD_SET_CONFIG "$CONFIG_NAME" "$key" "$value"
+}
+
+is_first_run() {
+    # Check if we've ever saved settings
+    local val=$(PAYLOAD_GET_CONFIG "$CONFIG_NAME" first_run_done 2>/dev/null)
+    [ "$val" != "true" ]
+}
+
+mark_first_run_done() {
+    save_setting "first_run_done" "true"
+}
+
+# Build ZIP URL (called after settings are loaded)
+build_zip_url() {
+    ZIP_URL="https://github.com/$GH_ORG/$GH_REPO/archive/refs/heads/$GH_BRANCH.zip"
+}
+
+# === FIRST RUN SETUP ===
+
+first_run_setup() {
+    LOG ""
+    LOG "=== WELCOME TO PAYLOAD MANAGER ==="
+    LOG ""
+    LOG "Let's configure your preferences."
+    LOG ""
+    LOG green "Press GREEN to continue"
+    WAIT_FOR_BUTTON_PRESS A
+
+    # Default update mode
+    LOG ""
+    LOG "=== UPDATE MODE ==="
+    LOG "When updates are available:"
+    LOG "1) Ask each time (recommended)"
+    LOG "2) Always review individually"
+    LOG "3) Always update all automatically"
+    LOG ""
+    LOG green "Press GREEN when ready"
+    WAIT_FOR_BUTTON_PRESS A
+
+    local mode_choice=$(NUMBER_PICKER "Select mode" 1)
+    case "$mode_choice" in
+        1) SETTING_DEFAULT_MODE="ask" ;;
+        2) SETTING_DEFAULT_MODE="interactive" ;;
+        3) SETTING_DEFAULT_MODE="batch" ;;
+        *) SETTING_DEFAULT_MODE="ask" ;;
+    esac
+    save_setting "default_mode" "$SETTING_DEFAULT_MODE"
+
+    # Custom repository
+    LOG ""
+    LOG "=== REPOSITORY ==="
+    local repo_resp=$(CONFIRMATION_DIALOG "Use official Hak5 repository?")
+    if [ "$repo_resp" != "$DUCKYSCRIPT_USER_CONFIRMED" ]; then
+        LOG ""
+        LOG "Enter custom repo (user/repo format):"
+        LOG green "Press GREEN when ready"
+        WAIT_FOR_BUTTON_PRESS A
+        local custom_repo=$(TEXT_PICKER "Repository" "")
+        if [ -n "$custom_repo" ]; then
+            SETTING_CUSTOM_REPO="$custom_repo"
+            save_setting "custom_repo" "$SETTING_CUSTOM_REPO"
+            GH_ORG=$(echo "$custom_repo" | cut -d'/' -f1)
+            GH_REPO=$(echo "$custom_repo" | cut -d'/' -f2)
+        fi
+
+        LOG ""
+        LOG "Enter branch name (or leave empty for master):"
+        LOG green "Press GREEN when ready"
+        WAIT_FOR_BUTTON_PRESS A
+        local custom_branch=$(TEXT_PICKER "Branch" "master")
+        if [ -n "$custom_branch" ] && [ "$custom_branch" != "master" ]; then
+            SETTING_CUSTOM_BRANCH="$custom_branch"
+            save_setting "custom_branch" "$SETTING_CUSTOM_BRANCH"
+            GH_BRANCH="$custom_branch"
+        fi
+    fi
+
+    # Show local-only payloads
+    LOG ""
+    local local_resp=$(CONFIRMATION_DIALOG "Show local-only payloads in browse?")
+    if [ "$local_resp" = "$DUCKYSCRIPT_USER_CONFIRMED" ]; then
+        SETTING_SHOW_LOCAL="true"
+    else
+        SETTING_SHOW_LOCAL="false"
+    fi
+    save_setting "show_local" "$SETTING_SHOW_LOCAL"
+
+    # Mark setup complete
+    mark_first_run_done
+    build_zip_url
+
+    LOG ""
+    LOG "Setup complete!"
+    LOG ""
+    LOG "Repository: $GH_ORG/$GH_REPO"
+    LOG "Branch: $GH_BRANCH"
+    LOG "Update mode: $SETTING_DEFAULT_MODE"
+    LOG ""
+    LOG green "Press GREEN to continue"
+    WAIT_FOR_BUTTON_PRESS A
+}
+
+# === SETTINGS MENU ===
+
+show_settings_menu() {
+    while true; do
+        LOG ""
+        LOG "=== SETTINGS ==="
+        LOG "1) Update mode: $SETTING_DEFAULT_MODE"
+        LOG "2) Repository: ${SETTING_CUSTOM_REPO:-hak5/wifipineapplepager-payloads}"
+        LOG "3) Branch: ${SETTING_CUSTOM_BRANCH:-master}"
+        LOG "4) Show local payloads: $SETTING_SHOW_LOCAL"
+        LOG "5) Reset to defaults"
+        LOG "6) Back"
+        LOG ""
+        LOG green "Press GREEN when ready"
+        WAIT_FOR_BUTTON_PRESS A
+
+        local choice=$(NUMBER_PICKER "Select option" 1)
+
+        case "$choice" in
+            1) settings_update_mode ;;
+            2) settings_repository ;;
+            3) settings_branch ;;
+            4) settings_show_local ;;
+            5) settings_reset ;;
+            6) return ;;
+        esac
+    done
+}
+
+settings_update_mode() {
+    LOG ""
+    LOG "=== UPDATE MODE ==="
+    LOG "1) Ask each time"
+    LOG "2) Always interactive"
+    LOG "3) Always batch"
+    LOG ""
+    LOG green "Press GREEN when ready"
+    WAIT_FOR_BUTTON_PRESS A
+
+    local choice=$(NUMBER_PICKER "Select mode" 1)
+    case "$choice" in
+        1) SETTING_DEFAULT_MODE="ask" ;;
+        2) SETTING_DEFAULT_MODE="interactive" ;;
+        3) SETTING_DEFAULT_MODE="batch" ;;
+        *) return ;;
+    esac
+    save_setting "default_mode" "$SETTING_DEFAULT_MODE"
+    LOG "Saved: $SETTING_DEFAULT_MODE"
+}
+
+settings_repository() {
+    LOG ""
+    local use_default=$(CONFIRMATION_DIALOG "Use official Hak5 repository?")
+    if [ "$use_default" = "$DUCKYSCRIPT_USER_CONFIRMED" ]; then
+        SETTING_CUSTOM_REPO=""
+        save_setting "custom_repo" ""
+        GH_ORG="hak5"
+        GH_REPO="wifipineapplepager-payloads"
+        build_zip_url
+        LOG "Reset to official repository"
+    else
+        LOG ""
+        LOG "Enter repo (user/repo format):"
+        LOG green "Press GREEN when ready"
+        WAIT_FOR_BUTTON_PRESS A
+        local custom_repo=$(TEXT_PICKER "Repository" "$SETTING_CUSTOM_REPO")
+        if [ -n "$custom_repo" ]; then
+            SETTING_CUSTOM_REPO="$custom_repo"
+            save_setting "custom_repo" "$SETTING_CUSTOM_REPO"
+            GH_ORG=$(echo "$custom_repo" | cut -d'/' -f1)
+            GH_REPO=$(echo "$custom_repo" | cut -d'/' -f2)
+            build_zip_url
+            LOG "Saved: $custom_repo"
+        fi
+    fi
+    # Clear cached download since repo changed
+    GITHUB_DOWNLOADED=false
+}
+
+settings_branch() {
+    LOG ""
+    LOG "Enter branch name:"
+    LOG green "Press GREEN when ready"
+    WAIT_FOR_BUTTON_PRESS A
+    local branch=$(TEXT_PICKER "Branch" "${SETTING_CUSTOM_BRANCH:-master}")
+    if [ -n "$branch" ]; then
+        if [ "$branch" = "master" ]; then
+            SETTING_CUSTOM_BRANCH=""
+            save_setting "custom_branch" ""
+        else
+            SETTING_CUSTOM_BRANCH="$branch"
+            save_setting "custom_branch" "$branch"
+        fi
+        GH_BRANCH="$branch"
+        build_zip_url
+        LOG "Saved: $branch"
+    fi
+    # Clear cached download since branch changed
+    GITHUB_DOWNLOADED=false
+}
+
+settings_show_local() {
+    if [ "$SETTING_SHOW_LOCAL" = "true" ]; then
+        SETTING_SHOW_LOCAL="false"
+    else
+        SETTING_SHOW_LOCAL="true"
+    fi
+    save_setting "show_local" "$SETTING_SHOW_LOCAL"
+    LOG "Show local payloads: $SETTING_SHOW_LOCAL"
+}
+
+settings_reset() {
+    local resp=$(CONFIRMATION_DIALOG "Reset all settings to defaults?")
+    if [ "$resp" = "$DUCKYSCRIPT_USER_CONFIRMED" ]; then
+        PAYLOAD_DEL_CONFIG "$CONFIG_NAME" default_mode
+        PAYLOAD_DEL_CONFIG "$CONFIG_NAME" custom_repo
+        PAYLOAD_DEL_CONFIG "$CONFIG_NAME" custom_branch
+        PAYLOAD_DEL_CONFIG "$CONFIG_NAME" show_local
+        PAYLOAD_DEL_CONFIG "$CONFIG_NAME" first_run_done
+
+        # Reset runtime values
+        SETTING_DEFAULT_MODE="ask"
+        SETTING_CUSTOM_REPO=""
+        SETTING_CUSTOM_BRANCH=""
+        SETTING_SHOW_LOCAL="true"
+        GH_ORG="hak5"
+        GH_REPO="wifipineapplepager-payloads"
+        GH_BRANCH="master"
+        build_zip_url
+        GITHUB_DOWNLOADED=false
+
+        LOG "Settings reset to defaults"
+    fi
+}
 
 # Detect target directory
 if [ -d "/mmc/root/payloads" ]; then
@@ -177,7 +447,7 @@ scan_github_payloads() {
 # === DIFF/COMPARISON LOGIC ===
 
 # Build comprehensive diff between local and GitHub
-# Format: rel_path|name|github_ver|local_ver|status
+# Format: rel_path|name|github_ver|local_ver|status|disabled
 build_payload_diff() {
     LOG "Scanning local payloads..."
     scan_local_payloads
@@ -213,34 +483,32 @@ build_payload_diff() {
         done < "$LOCAL_CACHE"
 
         if [ "$found" = false ]; then
-            echo "$gh_rel_path|$gh_name|$gh_version||$STATUS_NEW" >> "$DIFF_CACHE"
-        elif [ "$is_disabled" = true ]; then
-            echo "$gh_rel_path|$gh_name|$gh_version|$local_version|$STATUS_DISABLED" >> "$DIFF_CACHE"
+            echo "$gh_rel_path|$gh_name|$gh_version||$STATUS_NEW|false" >> "$DIFF_CACHE"
         elif version_newer "$gh_version" "$local_version"; then
-            echo "$gh_rel_path|$gh_name|$gh_version|$local_version|$STATUS_OUTDATED" >> "$DIFF_CACHE"
+            echo "$gh_rel_path|$gh_name|$gh_version|$local_version|$STATUS_OUTDATED|$is_disabled" >> "$DIFF_CACHE"
         else
-            echo "$gh_rel_path|$gh_name|$gh_version|$local_version|$STATUS_OK" >> "$DIFF_CACHE"
+            echo "$gh_rel_path|$gh_name|$gh_version|$local_version|$STATUS_OK|$is_disabled" >> "$DIFF_CACHE"
         fi
     done < "$GITHUB_CACHE"
 
-    # Find local-only payloads
-    while IFS='|' read -r loc_rel_path loc_name loc_version loc_disabled; do
-        [ -z "$loc_name" ] && continue
+    # Find local-only payloads (if show_local is enabled)
+    if [ "$SETTING_SHOW_LOCAL" = "true" ]; then
+        while IFS='|' read -r loc_rel_path loc_name loc_version loc_disabled; do
+            [ -z "$loc_name" ] && continue
 
-        local in_github=false
-        while IFS='|' read -r gh_rel_path gh_name gh_version; do
-            if [ "$gh_name" = "$loc_name" ]; then
-                in_github=true
-                break
+            local in_github=false
+            while IFS='|' read -r gh_rel_path gh_name gh_version; do
+                if [ "$gh_name" = "$loc_name" ]; then
+                    in_github=true
+                    break
+                fi
+            done < "$GITHUB_CACHE"
+
+            if [ "$in_github" = false ]; then
+                echo "$loc_rel_path|$loc_name||$loc_version|$STATUS_LOCAL|$loc_disabled" >> "$DIFF_CACHE"
             fi
-        done < "$GITHUB_CACHE"
-
-        if [ "$in_github" = false ]; then
-            local status="$STATUS_LOCAL"
-            [ "$loc_disabled" = "true" ] && status="$STATUS_DISABLED"
-            echo "$loc_rel_path|$loc_name||$loc_version|$status" >> "$DIFF_CACHE"
-        fi
-    done < "$LOCAL_CACHE"
+        done < "$LOCAL_CACHE"
+    fi
 
     LED FINISH
     return 0
@@ -375,6 +643,12 @@ update_payload() {
     local src_lib="$TEMP_DIR/$GH_REPO-$GH_BRANCH/library"
     local src_path="$src_lib/$rel_path"
     local target_path="$TARGET_DIR/$rel_path"
+    local was_disabled=false
+
+    # Preserve disabled state across update
+    if [ -f "$target_path/payload.sh.disabled" ]; then
+        was_disabled=true
+    fi
 
     # Self-update protection
     if [ -f "$target_path/payload.sh" ] && [ "$target_path/payload.sh" -ef "$0" ]; then
@@ -398,6 +672,9 @@ update_payload() {
     rm -rf "$target_path"
 
     if cp -rf "$src_path" "$target_path" 2>/dev/null; then
+        if [ "$was_disabled" = true ] && [ -f "$target_path/payload.sh" ]; then
+            mv "$target_path/payload.sh" "$target_path/payload.sh.disabled" 2>/dev/null
+        fi
         LED FINISH
         LOG "Updated: $name"
         return 0
@@ -414,11 +691,12 @@ show_main_menu() {
     while true; do
         LOG ""
         LOG "=== PAYLOAD MANAGER ==="
-        LOG "1) Browse & Compare (online)"
-        LOG "2) Check for Updates (online)"
-        LOG "3) Manage Installed (offline)"
-        LOG "4) Manage Disabled (offline)"
-        LOG "5) Exit"
+        LOG "1) Browse & Compare"
+        LOG "2) Check for Updates"
+        LOG "3) Manage Installed"
+        LOG "4) Manage Disabled"
+        LOG "5) Settings"
+        LOG "6) Exit"
         LOG ""
         LOG green "Press GREEN when ready"
         WAIT_FOR_BUTTON_PRESS A
@@ -430,7 +708,8 @@ show_main_menu() {
             2) check_updates ;;
             3) manage_installed ;;
             4) manage_disabled ;;
-            5) cleanup_and_exit ;;
+            5) show_settings_menu ;;
+            6) cleanup_and_exit ;;
             *) ;;
         esac
     done
@@ -527,18 +806,29 @@ browse_payloads_list() {
         local idx=1
         local payload_lines=()
 
-        while IFS='|' read -r rel_path name gh_ver loc_ver status; do
+        while IFS='|' read -r rel_path name gh_ver loc_ver status disabled; do
             if [[ "$rel_path" == $path_prefix/* ]]; then
                 local status_icon=""
-                case "$status" in
-                    "$STATUS_NEW") status_icon="[NEW]" ;;
-                    "$STATUS_OK") status_icon="[OK]" ;;
-                    "$STATUS_OUTDATED") status_icon="[UPD]" ;;
-                    "$STATUS_DISABLED") status_icon="[DIS]" ;;
-                    "$STATUS_LOCAL") status_icon="[LOC]" ;;
-                esac
+
+                if [ "$disabled" = "true" ]; then
+                    if [ "$status" = "$STATUS_OUTDATED" ]; then
+                        status_icon="[DIS][UPD]"
+                    elif [ "$status" = "$STATUS_LOCAL" ]; then
+                        status_icon="[DIS][LOC]"
+                    else
+                        status_icon="[DIS]"
+                    fi
+                else
+                    case "$status" in
+                        "$STATUS_NEW") status_icon="[NEW]" ;;
+                        "$STATUS_OK") status_icon="[OK]" ;;
+                        "$STATUS_OUTDATED") status_icon="[UPD]" ;;
+                        "$STATUS_LOCAL") status_icon="[LOC]" ;;
+                    esac
+                fi
+
                 LOG "$idx) $status_icon $name"
-                payload_lines+=("$rel_path|$name|$gh_ver|$loc_ver|$status")
+                payload_lines+=("$rel_path|$name|$gh_ver|$loc_ver|$status|$disabled")
                 idx=$((idx + 1))
             fi
         done < "$DIFF_CACHE"
@@ -569,7 +859,7 @@ browse_payloads_list() {
 
 show_payload_detail() {
     local payload_info="$1"
-    IFS='|' read -r rel_path name gh_ver loc_ver status <<< "$payload_info"
+    IFS='|' read -r rel_path name gh_ver loc_ver status disabled <<< "$payload_info"
 
     # Get metadata from appropriate source
     local pfile=""
@@ -591,7 +881,11 @@ show_payload_detail() {
     [ -n "$author" ] && LOG "Author: $author"
     LOG "GitHub: ${gh_ver:-N/A}"
     LOG "Local: ${loc_ver:-Not installed}"
-    LOG "Status: $status"
+    if [ "$disabled" = "true" ]; then
+        LOG "Status: $status (disabled)"
+    else
+        LOG "Status: $status"
+    fi
     LOG ""
 
     # Build action menu based on status
@@ -605,9 +899,15 @@ show_payload_detail() {
             action_idx=$((action_idx + 1))
             ;;
         "$STATUS_OK")
-            LOG "$action_idx) Disable"
-            actions+=("disable")
-            action_idx=$((action_idx + 1))
+            if [ "$disabled" = "true" ]; then
+                LOG "$action_idx) Enable"
+                actions+=("enable")
+                action_idx=$((action_idx + 1))
+            else
+                LOG "$action_idx) Disable"
+                actions+=("disable")
+                action_idx=$((action_idx + 1))
+            fi
             LOG "$action_idx) Uninstall"
             actions+=("uninstall")
             action_idx=$((action_idx + 1))
@@ -616,25 +916,29 @@ show_payload_detail() {
             LOG "$action_idx) Update"
             actions+=("update")
             action_idx=$((action_idx + 1))
-            LOG "$action_idx) Disable"
-            actions+=("disable")
-            action_idx=$((action_idx + 1))
-            LOG "$action_idx) Uninstall"
-            actions+=("uninstall")
-            action_idx=$((action_idx + 1))
-            ;;
-        "$STATUS_DISABLED")
-            LOG "$action_idx) Enable"
-            actions+=("enable")
-            action_idx=$((action_idx + 1))
+            if [ "$disabled" = "true" ]; then
+                LOG "$action_idx) Enable"
+                actions+=("enable")
+                action_idx=$((action_idx + 1))
+            else
+                LOG "$action_idx) Disable"
+                actions+=("disable")
+                action_idx=$((action_idx + 1))
+            fi
             LOG "$action_idx) Uninstall"
             actions+=("uninstall")
             action_idx=$((action_idx + 1))
             ;;
         "$STATUS_LOCAL")
-            LOG "$action_idx) Disable"
-            actions+=("disable")
-            action_idx=$((action_idx + 1))
+            if [ "$disabled" = "true" ]; then
+                LOG "$action_idx) Enable"
+                actions+=("enable")
+                action_idx=$((action_idx + 1))
+            else
+                LOG "$action_idx) Disable"
+                actions+=("disable")
+                action_idx=$((action_idx + 1))
+            fi
             LOG "$action_idx) Uninstall"
             actions+=("uninstall")
             action_idx=$((action_idx + 1))
@@ -668,10 +972,10 @@ check_updates() {
         return
     fi
 
-    local new_count=$(grep "|$STATUS_NEW$" "$DIFF_CACHE" 2>/dev/null | wc -l)
-    local upd_count=$(grep "|$STATUS_OUTDATED$" "$DIFF_CACHE" 2>/dev/null | wc -l)
-    local dis_count=$(grep "|$STATUS_DISABLED$" "$DIFF_CACHE" 2>/dev/null | wc -l)
-    local ok_count=$(grep "|$STATUS_OK$" "$DIFF_CACHE" 2>/dev/null | wc -l)
+    local new_count=$(grep "|$STATUS_NEW|" "$DIFF_CACHE" 2>/dev/null | wc -l)
+    local upd_count=$(grep "|$STATUS_OUTDATED|" "$DIFF_CACHE" 2>/dev/null | wc -l)
+    local dis_count=$(grep "|true$" "$DIFF_CACHE" 2>/dev/null | wc -l)
+    local ok_count=$(grep "|$STATUS_OK|" "$DIFF_CACHE" 2>/dev/null | wc -l)
     local total=$((new_count + upd_count))
 
     LOG ""
@@ -687,20 +991,25 @@ check_updates() {
         return
     fi
 
-    # Ask user how to proceed
-    local resp=$(CONFIRMATION_DIALOG "Review each payload individually?")
+    # Determine update mode based on settings
     local batch_mode=""
 
-    if [ "$resp" = "$DUCKYSCRIPT_USER_CONFIRMED" ]; then
-        # Interactive mode
+    if [ "$SETTING_DEFAULT_MODE" = "interactive" ]; then
         batch_mode="INTERACTIVE"
+    elif [ "$SETTING_DEFAULT_MODE" = "batch" ]; then
+        batch_mode="UPDATE_ALL"
     else
-        # Batch mode - ask what to do
-        local batch_resp=$(CONFIRMATION_DIALOG "Install/Update ALL $total payloads?")
-        if [ "$batch_resp" = "$DUCKYSCRIPT_USER_CONFIRMED" ]; then
-            batch_mode="UPDATE_ALL"
+        # "ask" mode - prompt user
+        local resp=$(CONFIRMATION_DIALOG "Review each payload individually?")
+        if [ "$resp" = "$DUCKYSCRIPT_USER_CONFIRMED" ]; then
+            batch_mode="INTERACTIVE"
         else
-            batch_mode="SKIP_ALL"
+            local batch_resp=$(CONFIRMATION_DIALOG "Install/Update ALL $total payloads?")
+            if [ "$batch_resp" = "$DUCKYSCRIPT_USER_CONFIRMED" ]; then
+                batch_mode="UPDATE_ALL"
+            else
+                batch_mode="SKIP_ALL"
+            fi
         fi
     fi
 
@@ -716,7 +1025,7 @@ check_updates() {
     local log_buffer=""
 
     # Process NEW payloads
-    while IFS='|' read -r rel_path name gh_ver loc_ver status; do
+    while IFS='|' read -r rel_path name gh_ver loc_ver status disabled; do
         [ "$status" != "$STATUS_NEW" ] && continue
 
         local do_install=false
@@ -747,7 +1056,7 @@ check_updates() {
     done < "$DIFF_CACHE"
 
     # Process OUTDATED payloads
-    while IFS='|' read -r rel_path name gh_ver loc_ver status; do
+    while IFS='|' read -r rel_path name gh_ver loc_ver status disabled; do
         [ "$status" != "$STATUS_OUTDATED" ] && continue
 
         local do_update=false
@@ -927,4 +1236,12 @@ cleanup_and_exit() {
 trap cleanup EXIT
 
 check_dependencies
+load_settings
+build_zip_url
+
+# First run setup
+if is_first_run; then
+    first_run_setup
+fi
+
 show_main_menu


### PR DESCRIPTION
## Summary

- Adds a new **Payload Manager** payload for managing payloads directly on the WiFi Pineapple Pager
- Browse, install, update, enable/disable payloads without needing a computer
- Compare installed payloads against the GitHub repository with status indicators (`[NEW]`, `[OK]`, `[UPD]`, `[DIS]`, `[LOC]`)
- Persistent settings via the Pager's config system (survives firmware upgrades)
- First-run setup wizard for initial configuration

## Features

- **Browse & Compare** - Navigate payloads by category with real-time status indicators
- **Check for Updates** - Summary view with interactive or batch update modes
- **Manage Installed/Disabled** - Enable, disable, or uninstall payloads (works offline)
- **Settings** - Configure update mode, custom repository/branch, display options
- **Self-update protection** - Queues own updates to apply on exit

## Settings

| Setting | Description |
|---------|-------------|
| Update mode | `ask`, `interactive`, or `batch` |
| Repository | Use official Hak5 repo or custom `user/repo` |
| Branch | Which branch to pull from |
| Show local payloads | Whether to display `[LOC]` payloads |
