### PR TITLE
DPAD-Timeout service sync to LCD

### DIFF
--- a/library/user/general/LEDs_Timeout/READEME.md
+++ b/library/user/general/LEDs_Timeout/READEME.md
@@ -1,8 +1,8 @@
-# DPAD Timeout
+# LED's Timeout
 
 ## Overview
 
-Automatically disables the DPAD LED when the screen dims or turns off to save battery. The LED turns back on when the screen wakes up.
+Automatically disables the LED when the screen dims or turns off to save battery. The LED turns back on when the screen wakes up.
 
 ## Features
 
@@ -13,12 +13,12 @@ Automatically disables the DPAD LED when the screen dims or turns off to save ba
 
 ## Installation
 
-Run the payload and confirm "Install DPAD Timeout service?"
+Run the payload and confirm "Install LED's Timeout service?"
 
 The service will:
 
-1. Create `/etc/init.d/dpad_timeout`
-2. Create `/usr/bin/DPADLED_TIMEOUT`
+1. Create `/etc/init.d/leds_timeout`
+2. Create `/usr/bin/LEDS_TIMEOUT`
 3. Enable and start the service
 
 ## Usage
@@ -44,8 +44,8 @@ Run the payload when service is running/stopped and select Uninstall.
 
 This removes:
 
-- `/etc/init.d/dpad_timeout`
-- `/usr/bin/DPADLED_TIMEOUT`
+- `/etc/init.d/leds_timeout`
+- `/usr/bin/LEDS_TIMEOUT`
 - Restores LED to default color
 
 ## Credits

--- a/library/user/general/LEDs_Timeout/payload.sh
+++ b/library/user/general/LEDs_Timeout/payload.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
-# Title: DPAD_Timeout
-# Description: Auto-disable DPAD LED when screen dims/turns off to save battery
+# Title: LED's_Timeout
+# Description: Auto-disable LED when screen dims/turns off to save battery
 # Author: Z3r0L1nk
 # Version: 1.0.0
 
-INIT_SCRIPT="/etc/init.d/dpad_timeout"
-BIN_SCRIPT="/usr/bin/DPADLED_TIMEOUT"
+INIT_SCRIPT="/etc/init.d/leds_timeout"
+BIN_SCRIPT="/usr/bin/LEDS_TIMEOUT"
 
 install_service() {
     LED SETUP
-    LOG "Installing DPAD Timeout service..."
+    LOG "Installing LED's Timeout service..."
 
     # Create init.d service
     cat > "$INIT_SCRIPT" << 'EOF'
@@ -19,7 +19,7 @@ USE_PROCD=1
 
 start_service() {
     procd_open_instance
-    procd_set_param command /usr/bin/DPADLED_TIMEOUT
+    procd_set_param command /usr/bin/LEDS_TIMEOUT
     procd_set_param respawn 3600 5 5
     procd_set_param stdout 1
     procd_set_param stderr 1
@@ -91,12 +91,12 @@ EOF
     "$INIT_SCRIPT" start
 
     LED FINISH
-    LOG "DPAD Timeout service installed and started!"
+    LOG "LED's Timeout service installed and started!"
 }
 
 uninstall_service() {
     LED SETUP
-    LOG "Uninstalling DPAD Timeout service..."
+    LOG "Uninstalling LED's Timeout service..."
 
     # Stop and disable
     if [ -f "$INIT_SCRIPT" ]; then
@@ -114,12 +114,12 @@ uninstall_service() {
     echo 1 > /sys/class/leds/b-button-led/brightness 2>/dev/null
 
     LED FINISH
-    LOG "DPAD Timeout service uninstalled!"
+    LOG "LED's Timeout service uninstalled!"
 }
 
 check_status() {
     if [ -f "$INIT_SCRIPT" ] && [ -f "$BIN_SCRIPT" ]; then
-        if pgrep -f "DPADLED_TIMEOUT" > /dev/null; then
+        if pgrep -f "LEDS_TIMEOUT" > /dev/null; then
             echo "running"
         else
             echo "stopped"
@@ -135,7 +135,7 @@ STATUS=$(check_status)
 
 case "$STATUS" in
     "running")
-        if [ "$(CONFIRMATION_DIALOG "DPAD Timeout is RUNNING. Uninstall?")" == "1" ]; then
+        if [ "$(CONFIRMATION_DIALOG "LED's Timeout is RUNNING. Uninstall?")" == "1" ]; then
             uninstall_service
         else
             LOG "No changes made."
@@ -151,7 +151,7 @@ case "$STATUS" in
         fi
         ;;
     "not_installed")
-        if [ "$(CONFIRMATION_DIALOG "Install DPAD Timeout service?")" == "1" ]; then
+        if [ "$(CONFIRMATION_DIALOG "Install LED's Timeout service?")" == "1" ]; then
             install_service
         else
             LOG "Installation cancelled."


### PR DESCRIPTION
Payload that installs service for Auto-disable LED's when screen dims/turns off to save battery.
Only RED LED will be on, to show that the pager is ON.
More in README.md

<img width="1044" height="703" alt="image" src="https://github.com/user-attachments/assets/406e6d22-3858-4e05-8edb-01edf1eaeb18" />
