### PR TITLE
Add NullSec QuickScan and HandshakeHunter payloads

### DIFF
--- a/library/recon/access_point/NullSec-HandshakeHunter/README.md
+++ b/library/recon/access_point/NullSec-HandshakeHunter/README.md
@@ -1,22 +1,37 @@
 # NullSec HandshakeHunter
 
-Automated WPA/WPA2 handshake capture for WiFi Pineapple Pager.
+Automated WPA/WPA2 handshake capture with deauthentication.
 
-**Author:** [bad-antics](https://github.com/bad-antics)  
-**GitHub:** [nullsec-pineapple-suite](https://github.com/bad-antics/nullsec-pineapple-suite)  
+## Description
+
+Scans for WPA/WPA2 networks, automatically targets the strongest signal, and captures handshakes using deauthentication bursts. Saves captures for offline cracking.
+
+## Requirements
+
+**aircrack-ng suite** must be installed on your Pineapple Pager:
+
+```bash
+opkg update
+opkg install aircrack-ng
+```
 
 ## Features
 
-- Auto target scanning
-- Automated deauth
-- Handshake capture to /mmc/nullsec/handshakes/
+- Auto-scan for WPA/WPA2 networks
+- Automated target selection
+- Deauth bursts to capture handshake
+- Saves to `/mmc/nullsec/handshakes/`
 
-## Part of NullSec Suite
+## Output
 
-58 professional WiFi payloads: https://github.com/bad-antics/nullsec-pineapple-suite
+- Captured `.cap` files ready for cracking with hashcat/aircrack-ng
+- Named with SSID and timestamp for easy identification
 
-## Disclaimer
+## Author
 
-For authorized security testing only.
+**bad-antics** - [GitHub](https://github.com/bad-antics)
 
-**© 2026 bad-antics**
+Part of the [NullSec Pineapple Suite](https://github.com/bad-antics/nullsec-pineapple-suite)
+
+---
+*For authorized security testing and educational purposes only.*

--- a/library/recon/access_point/NullSec-QuickScan/README.md
+++ b/library/recon/access_point/NullSec-QuickScan/README.md
@@ -1,22 +1,31 @@
 # NullSec QuickScan
 
-Fast 30-second WiFi environment scan with security analysis for WiFi Pineapple Pager.
+Fast 30-second WiFi environment scan with detailed security analysis.
 
-**Author:** [bad-antics](https://github.com/bad-antics)  
-**GitHub:** [nullsec-pineapple-suite](https://github.com/bad-antics/nullsec-pineapple-suite)  
+## Description
 
-## Features
+Quick reconnaissance scan of all nearby WiFi networks. Displays network count, security type breakdown (WPA3/WPA2/WEP/Open), and prepares environment analysis.
 
-- 30-second fast scan
-- Security breakdown (WPA3/WPA2/WEP/Open)
-- Clean Pager UI integration
+## Requirements
 
-## Part of NullSec Suite
+**aircrack-ng suite** must be installed on your Pineapple Pager:
 
-58 professional WiFi payloads: https://github.com/bad-antics/nullsec-pineapple-suite
+```bash
+opkg update
+opkg install aircrack-ng
+```
 
-## Disclaimer
+## Output
 
-For authorized security testing only.
+- Total network count
+- Security breakdown (WPA3, WPA2, WEP, Open)
+- Quick assessment of WiFi environment
 
-**© 2026 bad-antics**
+## Author
+
+**bad-antics** - [GitHub](https://github.com/bad-antics)
+
+Part of the [NullSec Pineapple Suite](https://github.com/bad-antics/nullsec-pineapple-suite)
+
+---
+*For authorized security testing and educational purposes only.*

--- a/library/recon/access_point/NullSec-QuickScan/payload.sh
+++ b/library/recon/access_point/NullSec-QuickScan/payload.sh
@@ -3,8 +3,23 @@
 # Author: bad-antics
 # Description: Fast 30-second WiFi environment scan with detailed security analysis
 # Category: Recon
-# Version: 1.0
+# Version: 1.1
+# Requires: aircrack-ng suite (airodump-ng, airmon-ng)
 # GitHub: https://github.com/bad-antics/nullsec-pineapple-suite
+
+# Check dependencies
+if ! command -v airodump-ng >/dev/null 2>&1; then
+    ERROR_DIALOG "Missing aircrack-ng!
+
+This payload requires:
+- airodump-ng
+- airmon-ng
+
+Install via:
+opkg update
+opkg install aircrack-ng"
+    exit 1
+fi
 
 PROMPT "NULLSEC QUICKSCAN
 
@@ -21,14 +36,14 @@ Press OK to start scan."
 
 [ ! -d "/sys/class/net/wlan0" ] && { ERROR_DIALOG "wlan0 not found!"; exit 1; }
 
-SPINNER_START "Scanning 30 seconds..."
-
+SPINNER_START "Enabling monitor..."
 airmon-ng start wlan0 >/dev/null 2>&1
 MON_IF=$(iw dev | grep -oE "wlan[0-9]mon" | head -1)
 [ -z "$MON_IF" ] && MON_IF="wlan0"
+SPINNER_STOP
 
+SPINNER_START "Scanning 30 seconds..."
 timeout 30 airodump-ng "$MON_IF" --write-interval 5 -w /tmp/quickscan --output-format csv 2>/dev/null
-
 SPINNER_STOP
 
 CSV_FILE=$(ls /tmp/quickscan*.csv 2>/dev/null | head -1)


### PR DESCRIPTION
## New Payloads

### NullSec-QuickScan
Fast 30-second WiFi environment scan with security analysis.
- Network count
- Security breakdown (WPA3/WPA2/WEP/Open)
- Clean Pager UI integration

### NullSec-HandshakeHunter
Automated WPA/WPA2 handshake capture with deauthentication.
- Auto target scanning
- Automated deauth bursts
- Saves captures to /mmc/nullsec/handshakes/

## Requirements
Both payloads require **aircrack-ng** suite:
```bash
opkg update
opkg install aircrack-ng
```

## Part of NullSec Pineapple Suite

These are from the [NullSec Pineapple Suite](https://github.com/bad-antics/nullsec-pineapple-suite) - a collection of 58 professional WiFi security payloads.

## Testing
- Tested on WiFi Pineapple Pager firmware 1.0.6
- All payloads verified working with aircrack-ng suite

## Author
[bad-antics](https://github.com/bad-antics)

---
*For authorized security testing and educational purposes only.*