### PR TITLE
Recon DB Report Payload

### DIFF
--- a/library/user/reconnaissance/recondb_reporting/README.md
+++ b/library/user/reconnaissance/recondb_reporting/README.md
@@ -1,0 +1,275 @@
+# Engagement Report Generator
+
+**Device:** WiFi Pineapple Pager (8th gen PineAP)
+**Type:** User payload
+**Version:** 3.5
+**Author:** Digs
+
+---
+
+## Overview
+
+The Engagement Report Generator produces a formatted plain-text report and a CSV file from the Pager's native recon database at the end of a wireless reconnaissance session. No duplicate recon logic -- it reads directly from `/root/recon/recon.db`, which the PineAP engine maintains continuously in the background.
+
+Each run produces two files in `/root/loot/reports/`:
+
+- `report_TIMESTAMP.txt` -- formatted text report with all sections
+- `report_TIMESTAMP.csv` -- AP data in spreadsheet-ready format
+
+---
+
+## Requirements
+
+`sqlite3` must be installed on the device. Check and install if missing:
+
+```bash
+which sqlite3
+opkg update && opkg install sqlite3-cli
+```
+
+---
+
+## Installation
+
+```bash
+# Create payload directory
+mkdir -p /root/payloads/user/reconnaissance/recon_db_reporting
+
+# Copy payload to device from workstation
+scp payload.sh root@172.16.42.1:/root/payloads/user/reconnaissance/recon_db_reporting/payload.sh
+
+# Make executable
+ssh root@172.16.42.1 'chmod +x /root/payloads/user/reconnaissance/recon_db_reporting/payload.sh'
+```
+
+---
+
+## Before Each Engagement
+
+The payload has three metadata fields hardcoded near the top of the script. Update these before deploying for each engagement via SSH:
+
+```bash
+ssh root@172.16.42.1
+cd /root/payloads/user/reporting/recon_reports
+
+sed -i 's/^engagement=.*/engagement="Q2 2026 Wireless Assessment"/' payload.sh
+sed -i 's/^target_org=.*/target_org="Acme Corp"/' payload.sh
+sed -i 's/^operator=.*/operator="Digs"/' payload.sh
+```
+
+Or edit directly with vi:
+
+```bash
+vi /root/payloads/user/reconnaissance/recon_db_reporting/payload.sh
+```
+
+The three lines are near the top right after the preflight block and are clearly labeled.
+
+> **Note:** The `TEXT_PICKER` interactive prompt is not functional in the current firmware version. This note will be updated when Hak5 releases a fix.
+
+---
+
+## Running the Payload
+
+1. Conduct your wireless recon session -- the PineAP engine collects AP, client, and handshake data continuously in the background
+2. When ready to generate the report, navigate to **Payloads** on the Pager dashboard
+3. Select **reconnaissance** and launch the payload
+4. Two spinners appear in sequence -- "Gathering data..." then "Writing report..."
+5. On completion: vibration fires and "Report ready" alert appears on screen
+
+Total runtime is typically under 30 seconds for a standard session.
+
+---
+
+## Recommended Workflow
+
+```
+1. Update engagement metadata (SSH, 30 seconds)
+2. Conduct recon session -- walk or drive the target area
+3. If using GPS: enable WiGLE logging under Recon > Settings
+4. Run the Engagement Report Generator payload
+5. Retrieve output files via SCP or Virtual Pager
+```
+
+---
+
+## Report Sections
+
+| Section | Contents |
+|---|---|
+| Header | Engagement name, target, operator, timestamp, GPS location if available |
+| Executive Summary | Counts for all finding categories, encryption breakdown, band coverage |
+| 1 -- Recon Sessions | All named recon sessions with start times |
+| 2 -- Access Points | Up to 200 APs sorted by signal: BSSID, SSID, band, channel, encryption, signal, packets |
+| 3 -- Open Networks | All unencrypted APs flagged as priority findings |
+| 4 -- Client Devices | Top 100 clients by signal: MAC, probed SSID, band, first seen |
+| 5 -- Handshake Captures | Captured .pcap and .22000 files with Hashcat crack command |
+| 6 -- Credentials | Plaintext credentials captured via Evil WPA (hostap_basic table) |
+| 7 -- GPS and AP Locations | GPS fix at report time, WiGLE log summary if present |
+| 8 -- Rogue AP Detections | Events from the Rogue AP Detector payload if deployed |
+| 9 -- Loot Retrieval | Pre-populated SCP commands for all output files |
+
+---
+
+## CSV Output
+
+The CSV file contains AP data with the following columns:
+
+```
+BSSID, SSID, Band, Channel, Encryption, Signal, Packets, Hidden, Last_Seen
+```
+
+- Up to 500 APs included, sorted by signal strength descending
+- Compatible with Excel, Google Sheets, and any standard CSV tool
+- SSID fields with commas or quotes are properly escaped by SQLite CSV mode
+
+---
+
+## Data Sources
+
+All data comes from sources the Pager maintains natively -- no duplicate recon logic.
+
+| Report section | Source |
+|---|---|
+| AP list, client list, sessions | `/root/recon/recon.db` (SQLite) |
+| Handshake files | `/root/loot/handshakes/` |
+| GPS fix | `GPS_GET` command (requires USB GPS adapter) |
+| WiGLE AP locations | `/root/loot/wigle/*.csv` (requires GPS + WiGLE logging enabled) |
+| Rogue AP events | `/root/loot/rogue_ap/detections.log` (requires Rogue AP Detector payload) |
+
+### Encryption decoding
+
+The `encryption` field in `recon.db` is a packed bitmask of cipher capability flags from beacon RSN Information Elements. The payload decodes it as follows:
+
+| Label | Condition |
+|---|---|
+| Open | encryption = 0 or NULL |
+| WEP | bit 2 set, bit 8 clear |
+| WPA2 | bit 8 set, bits 16 and 64 clear |
+| WPA/WPA2 | bits 4 and 8 set, bits 16 and 64 clear |
+| WPA2/WPA3 | bits 8 and 16 set, or bits 8 and 64 set |
+| WPA3 | bit 16 or 64 set, bit 8 clear |
+
+### ssid.type values
+
+| Value | Meaning |
+|---|---|
+| 4 | Probe request (client scanning) |
+| 5 | Probe response (AP replying) |
+| 8 | Beacon (AP advertising) |
+
+The report filters `type=8` for AP enumeration and `type=4` for client enumeration.
+
+---
+
+## Retrieving Output Files
+
+Default Pager IP over USB-C Ethernet: `172.16.42.1`
+
+```bash
+# Text report
+scp root@172.16.42.1:/root/loot/reports/report_*.txt ./
+
+# CSV
+scp root@172.16.42.1:/root/loot/reports/report_*.csv ./
+
+# Full loot directory
+scp -r root@172.16.42.1:/root/loot/ ./pager_loot/
+
+# Recon database (for offline analysis)
+scp root@172.16.42.1:/root/recon/recon.db ./recon_$(date +%Y%m%d).db
+
+# WiGLE logs
+scp root@172.16.42.1:/root/loot/wigle/*.csv ./
+
+# Handshakes
+scp -r root@172.16.42.1:/root/loot/handshakes/ ./handshakes/
+```
+
+Files can also be downloaded via the Virtual Pager web interface at `http://172.16.42.1`.
+
+---
+
+## GPS Support
+
+GPS data is included automatically when a USB GPS adapter is connected and has a valid fix.
+
+**Supported hardware:** Any USB serial GPS receiver. Tested with g-mouse adapters and the Glytch GPS Mod. Multi-constellation receivers (GPS + GLONASS + Galileo + BeiDou) provide faster locks and better accuracy.
+
+**Setup:**
+1. Connect USB GPS to the USB-A port
+2. Configure under Settings > GPS -- select serial port and baud rate (typically 9600 or 115200)
+3. Wait for GPS fix -- may take 15-30 minutes on a cold start outdoors with a clear sky view
+
+**WiGLE wardriving:**
+1. Confirm GPS fix is active
+2. Enable WiGLE logging: Recon > Settings > WiGLE
+3. Survey the target area on foot or by vehicle
+4. The report will include a geographic bounding box and per-AP location table
+
+**Accuracy note:** GPS accuracy varies significantly based on sky visibility. Values over 100m indicate a weak fix and should be treated as approximate. Indoor use is generally not possible with pure GPS hardware.
+
+---
+
+## Offline Database Analysis
+
+The recon database can be copied to a workstation for deeper analysis using any SQLite tool.
+
+```bash
+scp root@172.16.42.1:/root/recon/recon.db ./recon.db
+
+# All APs with encryption labels
+sqlite3 recon.db "SELECT
+  substr(bssid,1,2)||':'||substr(bssid,3,2)||':'||substr(bssid,5,2)||':'||
+  substr(bssid,7,2)||':'||substr(bssid,9,2)||':'||substr(bssid,11,2) AS bssid,
+  CAST(ssid AS TEXT) AS ssid,
+  channel, signal
+FROM ssid WHERE type=8 ORDER BY signal DESC;"
+
+# Open networks only
+sqlite3 recon.db "SELECT CAST(ssid AS TEXT), channel, signal
+FROM ssid WHERE type=8 AND (encryption=0 OR encryption IS NULL)
+ORDER BY signal DESC;"
+
+# Client probe history
+sqlite3 recon.db "SELECT DISTINCT
+  w.mac, CAST(s.ssid AS TEXT) AS probed
+FROM ssid s JOIN wifi_device w ON s.wifi_device=w.hash
+WHERE s.type=4 ORDER BY w.mac;"
+```
+
+---
+
+## Known Limitations
+
+**TEXT_PICKER not functional:** Interactive metadata prompts do not work in the current firmware. Engagement name, target org, and operator are hardcoded variables edited via SSH before each run. Monitor Hak5 firmware release notes for updates.
+
+**Client count:** With large wardriving datasets (27,000+ clients observed), the client section is limited to the top 100 by signal strength to keep the report readable. The full count appears in the executive summary.
+
+**WiGLE GPS accuracy:** The first WiGLE observations after enabling GPS logging may have high accuracy values (100m+) while the GPS warms up. These are included but noted in the report.
+
+**Handshake capture:** WPA3 networks and 6 GHz networks do not produce crackable handshakes. Handshake capture is most reliable on 2.4 GHz WPA2 networks with active clients. Lock to a specific channel with `PINEAPPLE_EXAMINE_BSSID` to maximize capture chances.
+
+---
+
+## Related Payloads
+
+This payload is designed to run at the end of a session that may include:
+
+| Payload | Type | Purpose |
+|---|---|---|
+| Passive WiFi Survey | User | Session-isolated recon with PCAP capture |
+| Rogue AP Detector | User (daemon) | Monitors for known SSIDs on unexpected BSSIDs |
+
+---
+
+## References
+
+| Resource | URL |
+|---|---|
+| Pager docs | https://docs.hak5.org/wifi-pineapple-pager/ |
+| Recon database | https://docs.hak5.org/wifi-pineapple-pager/device/recon/ |
+| Handshake collection | https://docs.hak5.org/wifi-pineapple-pager/pineapple-functions/handshake-collection/ |
+| GPS setup | https://docs.hak5.org/wifi-pineapple-pager/device/gps/ |
+| Payload types | https://docs.hak5.org/wifi-pineapple-pager/payloads/introduction-to-payloads/ |
+| Payload repository | https://github.com/hak5/wifipineapplepager-payloads |

--- a/library/user/reconnaissance/recondb_reporting/payload.sh
+++ b/library/user/reconnaissance/recondb_reporting/payload.sh
@@ -1,0 +1,287 @@
+#!/bin/bash
+# Title: Recon-DB Engagement Report Generator
+# Description: Queries native recon database and produces a plain-text
+#              engagement report. Uses exec stdout redirect for reliable
+#              file writing on BusyBox.
+# Author: 0xD1G5
+# Version: 3.5
+# Type: User payload
+# Category: Reorting
+# Requires: sqlite3 (opkg install sqlite3-cli if missing)
+
+# CONFIG
+RECON_DB=/root/recon/recon.db
+RECON_DB_COPY=/tmp/recon_report.db
+WIGLE_DIR=/root/loot/wigle
+HANDSHAKE_DIR=/root/loot/handshakes
+ROGUE_LOG=/root/loot/rogue_ap/detections.log
+REPORT_DIR=/root/loot/reports
+
+# PREFLIGHT
+if ! which sqlite3 > /dev/null 2>&1; then
+    ALERT "sqlite3 not found. Run: opkg install sqlite3-cli"
+    exit 1
+fi
+
+if [ ! -f $RECON_DB ]; then
+    ALERT "Recon database not found at $RECON_DB"
+    exit 1
+fi
+
+# METADATA
+engagement="DATE_LOCATION_WIRELESS_RECON"
+target_org="Acme Corp"
+operator="UPDATE_WITH_YOUR_NAME"
+
+# SETUP
+mkdir -p $REPORT_DIR
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+RF=$REPORT_DIR/report_$TIMESTAMP.txt
+GENERATED_AT=$(date +%Y-%m-%d_%H:%M:%S)
+
+SPINNER1=$(START_SPINNER "Gathering data...")
+
+cp $RECON_DB $RECON_DB_COPY
+DB=$RECON_DB_COPY
+
+# GPS - 5 second timeout, fail gracefully
+gps_raw=$(timeout 5 GPS_GET 2>/dev/null)
+gps_lat=$(echo "$gps_raw" | cut -d' ' -f1)
+gps_lon=$(echo "$gps_raw" | cut -d' ' -f2)
+gps_alt=$(echo "$gps_raw" | cut -d' ' -f3)
+gps_acc=$(echo "$gps_raw" | cut -d' ' -f4)
+gps_available=0
+if [ -n "$gps_lat" ] && [ "$gps_lat" != "0" ] && [ "$gps_lat" != "0.000000" ]; then
+    gps_available=1
+fi
+
+# WiGLE
+wigle_file=$(ls -t $WIGLE_DIR/*.csv 2>/dev/null | head -1)
+wigle_available=0
+wigle_ap_count=0
+if [ -n "$wigle_file" ] && [ -f "$wigle_file" ]; then
+    wigle_available=1
+    wigle_ap_count=$(tail -n +3 $wigle_file | grep -c WIFI 2>/dev/null)
+    [ -z "$wigle_ap_count" ] && wigle_ap_count=0
+fi
+
+# COUNTS - all via sqlite3
+session_count=$(sqlite3 $DB "SELECT count(*) FROM scan;")
+ap_total=$(sqlite3 $DB "SELECT count(*) FROM ssid WHERE type=8;")
+ap_hidden=$(sqlite3 $DB "SELECT count(*) FROM ssid WHERE type=8 AND hidden=1;")
+ap_open=$(sqlite3 $DB "SELECT count(*) FROM ssid WHERE type=8 AND (encryption=0 OR encryption IS NULL);")
+client_total=$(sqlite3 $DB "SELECT count(DISTINCT w.hash) FROM ssid s JOIN wifi_device w ON s.wifi_device=w.hash WHERE s.type=4;")
+enc_wpa2=$(sqlite3 $DB "SELECT count(*) FROM ssid WHERE type=8 AND (encryption & 8) != 0 AND (encryption & 16) = 0 AND (encryption & 64) = 0;")
+enc_wpa3=$(sqlite3 $DB "SELECT count(*) FROM ssid WHERE type=8 AND ((encryption & 16) != 0 OR (encryption & 64) != 0);")
+enc_mixed=$(sqlite3 $DB "SELECT count(*) FROM ssid WHERE type=8 AND (encryption & 4) != 0 AND (encryption & 8) != 0 AND (encryption & 16) = 0 AND (encryption & 64) = 0;")
+enc_wep=$(sqlite3 $DB "SELECT count(*) FROM ssid WHERE type=8 AND (encryption & 2) != 0 AND (encryption & 8) = 0;")
+band_24=$(sqlite3 $DB "SELECT count(*) FROM ssid WHERE type=8 AND s.freq < 5000;" 2>/dev/null || sqlite3 $DB "SELECT count(*) FROM ssid WHERE type=8 AND freq < 5000;")
+band_5=$(sqlite3 $DB "SELECT count(*) FROM ssid WHERE type=8 AND freq >= 5000 AND freq < 5925;")
+band_6=$(sqlite3 $DB "SELECT count(*) FROM ssid WHERE type=8 AND freq >= 5925;")
+hs_pcap=$(find $HANDSHAKE_DIR -name "*.pcap" 2>/dev/null | wc -l | tr -d ' ')
+hs_crack=$(find $HANDSHAKE_DIR -name "*.22000" 2>/dev/null | wc -l | tr -d ' ')
+rogue_count=0
+[ -f $ROGUE_LOG ] && rogue_count=$(grep -c ROGUE $ROGUE_LOG 2>/dev/null || echo 0)
+cred_count=$(sqlite3 $DB "SELECT count(*) FROM hostap_basic;")
+
+STOP_SPINNER $SPINNER1
+SPINNER2=$(START_SPINNER "Writing report...")
+
+# REDIRECT STDOUT TO REPORT FILE
+# Save original stdout to fd 3, redirect stdout to report file.
+# All echo and sqlite3 output below goes directly to the file.
+# Restore stdout before ALERT/VIBRATE/LOG at the end.
+exec 3>&1
+exec 1>$RF
+
+echo "================================================================================"
+echo "  WIRELESS RECONNAISSANCE ENGAGEMENT REPORT"
+echo "  WiFi Pineapple Pager -- Hak5 (8th gen PineAP)"
+echo "================================================================================"
+echo ""
+echo "  Engagement  : $engagement"
+echo "  Target      : $target_org"
+echo "  Operator    : $operator"
+echo "  Generated   : $GENERATED_AT"
+if [ $gps_available -eq 1 ]; then
+    echo "  Location    : $gps_lat, $gps_lon  (alt: ${gps_alt}m  acc: ${gps_acc}m)"
+fi
+
+echo ""
+echo "================================================================================"
+echo "  EXECUTIVE SUMMARY"
+echo "================================================================================"
+echo ""
+echo "  Recon sessions   : $session_count"
+echo "  Access points    : $ap_total observed  ($ap_hidden hidden, $ap_open open)"
+echo "  Client devices   : $client_total observed"
+echo "  Handshakes       : $hs_pcap captured  ($hs_crack Hashcat-ready)"
+[ $wigle_available -eq 1 ] && echo "  GPS-tagged APs   : $wigle_ap_count"
+echo "  Rogue AP events  : $rogue_count"
+[ "$cred_count" -gt 0 ] && echo "  !! Credentials   : $cred_count captured via Evil WPA"
+echo ""
+echo "  Encryption:"
+echo "    Open             : $ap_open"
+echo "    WEP              : $enc_wep"
+echo "    WPA2             : $enc_wpa2"
+echo "    WPA/WPA2 Mixed   : $enc_mixed"
+echo "    WPA3             : $enc_wpa3"
+echo ""
+echo "  Bands:"
+echo "    2.4 GHz : $band_24 APs"
+echo "    5 GHz   : $band_5 APs"
+echo "    6 GHz   : $band_6 APs"
+
+echo ""
+echo "================================================================================"
+echo "  SECTION 1 -- RECON SESSIONS"
+echo "================================================================================"
+sqlite3 $DB "SELECT '  Session ' || id || ': ' || COALESCE(name,'unnamed') || '  started ' || datetime(time,'unixepoch') FROM scan ORDER BY time;"
+
+echo ""
+echo "================================================================================"
+echo "  SECTION 2 -- ACCESS POINTS  ($ap_total observed)"
+echo "================================================================================"
+echo ""
+echo "  BSSID               SSID                     Band    Ch  Encryption           Sig  Pkts  Last seen"
+echo "  ----------------------------------------------------------------------------------------------------"
+sqlite3 $DB "SELECT printf('  %-19s %-24s %-7s %-3s %-20s %-4s %-4s %s', substr(s.bssid,1,2)||':'||substr(s.bssid,3,2)||':'||substr(s.bssid,5,2)||':'||substr(s.bssid,7,2)||':'||substr(s.bssid,9,2)||':'||substr(s.bssid,11,2), COALESCE(NULLIF(CAST(s.ssid AS TEXT),''),'[hidden]'), CASE WHEN s.freq >= 5925 THEN '6 GHz' WHEN s.freq >= 5000 THEN '5 GHz' ELSE '2.4GHz' END, s.channel, CASE WHEN s.encryption IS NULL OR s.encryption = 0 THEN 'Open' WHEN (s.encryption & 2) != 0 AND (s.encryption & 8) = 0 THEN 'WEP' WHEN ((s.encryption & 16) != 0 OR (s.encryption & 64) != 0) AND (s.encryption & 8) != 0 THEN 'WPA2/WPA3' WHEN (s.encryption & 16) != 0 OR (s.encryption & 64) != 0 THEN 'WPA3' WHEN (s.encryption & 4) != 0 AND (s.encryption & 8) != 0 THEN 'WPA/WPA2' WHEN (s.encryption & 8) != 0 THEN 'WPA2' ELSE 'Unknown' END, s.signal, w.packets, datetime(s.time,'unixepoch')) FROM ssid s JOIN wifi_device w ON s.wifi_device=w.hash WHERE s.type=8 ORDER BY s.signal DESC LIMIT 200;"
+
+echo ""
+echo "================================================================================"
+echo "  SECTION 3 -- OPEN NETWORKS  ($ap_open found)"
+echo "================================================================================"
+if [ "$ap_open" -eq 0 ]; then
+    echo "  No open access points observed."
+else
+    echo "  !! Unencrypted -- client traffic visible in plaintext."
+    echo ""
+    sqlite3 $DB "SELECT printf('  %-19s %-24s %-7s CH%-3s  %s dBm', substr(s.bssid,1,2)||':'||substr(s.bssid,3,2)||':'||substr(s.bssid,5,2)||':'||substr(s.bssid,7,2)||':'||substr(s.bssid,9,2)||':'||substr(s.bssid,11,2), COALESCE(NULLIF(CAST(s.ssid AS TEXT),''),'[hidden]'), CASE WHEN s.freq >= 5925 THEN '6 GHz' WHEN s.freq >= 5000 THEN '5 GHz' ELSE '2.4GHz' END, s.channel, s.signal) FROM ssid s JOIN wifi_device w ON s.wifi_device=w.hash WHERE s.type=8 AND (s.encryption=0 OR s.encryption IS NULL) ORDER BY s.signal DESC;"
+fi
+
+echo ""
+echo "================================================================================"
+echo "  SECTION 4 -- CLIENT DEVICES  ($client_total observed, top 100 by signal)"
+echo "================================================================================"
+echo ""
+echo "  Note: Modern devices randomize MACs. Empty SSID = passive scan."
+echo ""
+echo "  MAC                  Probed SSID              Sig   Band    First seen"
+echo "  ------------------------------------------------------------------------"
+if [ "$client_total" -eq 0 ]; then
+    echo "  No client devices observed."
+else
+    sqlite3 $DB "SELECT printf('  %-19s %-24s %-5s %-7s %s', substr(w.mac,1,2)||':'||substr(w.mac,3,2)||':'||substr(w.mac,5,2)||':'||substr(w.mac,7,2)||':'||substr(w.mac,9,2)||':'||substr(w.mac,11,2), COALESCE(NULLIF(CAST(s.ssid AS TEXT),''),'[broadcast]'), s.signal, CASE WHEN s.freq >= 5925 THEN '6 GHz' WHEN s.freq >= 5000 THEN '5 GHz' ELSE '2.4GHz' END, datetime(s.time,'unixepoch')) FROM ssid s JOIN wifi_device w ON s.wifi_device=w.hash WHERE s.type=4 GROUP BY w.mac ORDER BY s.signal DESC LIMIT 100;"
+fi
+
+echo ""
+echo "================================================================================"
+echo "  SECTION 5 -- HANDSHAKE CAPTURES"
+echo "================================================================================"
+if [ "$hs_pcap" -eq 0 ]; then
+    echo "  No handshakes captured."
+    echo "  Tip: PINEAPPLE_EXAMINE_BSSID <bssid> locks channel to improve capture rate."
+else
+    echo "  Total    : $hs_pcap"
+    echo "  Hashcat  : $hs_crack (.22000 format)"
+    echo ""
+    find $HANDSHAKE_DIR -name "*.pcap" 2>/dev/null | sort | while IFS= read -r f; do
+        size=$(ls -lh $f 2>/dev/null | awk '{print $5}')
+        echo "    $size  $(basename $f)"
+    done
+    echo ""
+    echo "  hashcat -m 22000 -a 0 capture.22000 wordlist.txt"
+fi
+
+echo ""
+echo "================================================================================"
+echo "  SECTION 6 -- CAPTURED CREDENTIALS (Evil WPA)"
+echo "================================================================================"
+if [ "$cred_count" -eq 0 ]; then
+    echo "  No credentials captured."
+else
+    echo "  !! $cred_count credential set(s) captured"
+    echo ""
+    sqlite3 $DB "SELECT printf('  %-20s %-12s %-20s %s', datetime(time,'unixepoch'), type, identity, password) FROM hostap_basic ORDER BY time;"
+fi
+
+echo ""
+echo "================================================================================"
+echo "  SECTION 7 -- GPS AND AP LOCATIONS"
+echo "================================================================================"
+if [ $gps_available -eq 1 ]; then
+    echo "  GPS fix at report time:"
+    echo "    Latitude  : $gps_lat"
+    echo "    Longitude : $gps_lon"
+    echo "    Altitude  : ${gps_alt}m"
+    echo "    Accuracy  : ${gps_acc}m"
+    echo ""
+    echo "  Maps: https://maps.google.com/?q=${gps_lat},${gps_lon}"
+else
+    echo "  No GPS fix. Connect USB GPS and ensure clear sky view."
+fi
+echo ""
+if [ $wigle_available -eq 0 ]; then
+    echo "  No WiGLE log. Enable: Recon > Settings > WiGLE (requires GPS)"
+else
+    echo "  WiGLE log  : $(basename $wigle_file)"
+    echo "  GPS-tagged : $wigle_ap_count APs"
+    echo ""
+    echo "  Upload: WIGLE_LOGIN and WIGLE_UPLOAD"
+fi
+
+echo ""
+echo "================================================================================"
+echo "  SECTION 8 -- ROGUE AP DETECTIONS"
+echo "================================================================================"
+if [ "$rogue_count" -eq 0 ]; then
+    if [ -f $ROGUE_LOG ]; then
+        echo "  Detector ran -- no events detected."
+    else
+        echo "  No detection log. Deploy Rogue AP Detector payload to enable."
+    fi
+else
+    echo "  Total events : $rogue_count"
+    echo ""
+    grep ROGUE $ROGUE_LOG
+fi
+
+echo ""
+echo "================================================================================"
+echo "  SECTION 9 -- LOOT RETRIEVAL"
+echo "================================================================================"
+echo ""
+echo "  Pager IP: 172.16.42.1"
+echo ""
+echo "  Report     : scp root@172.16.42.1:$RF ./"
+echo "  Full loot  : scp -r root@172.16.42.1:/root/loot/ ./loot_$TIMESTAMP/"
+echo "  Recon DB   : scp root@172.16.42.1:$RECON_DB ./recon_$TIMESTAMP.db"
+echo "  WiGLE      : scp root@172.16.42.1:/root/loot/wigle/*.csv ./"
+echo "  Handshakes : scp -r root@172.16.42.1:$HANDSHAKE_DIR/ ./handshakes/"
+echo ""
+echo "================================================================================"
+echo "  END OF REPORT -- $GENERATED_AT"
+echo "================================================================================"
+
+# CSV OUTPUT - written while stdout is still redirected to report file
+# Restore stdout first so CSV goes to its own file
+exec 1>&3
+exec 3>&-
+
+CF=$REPORT_DIR/report_$TIMESTAMP.csv
+
+# AP CSV
+sqlite3 -csv $DB "SELECT 'BSSID','SSID','Band','Channel','Encryption','Signal','Packets','Hidden','Last_Seen';" > $CF
+sqlite3 -csv $DB "SELECT substr(s.bssid,1,2)||':'||substr(s.bssid,3,2)||':'||substr(s.bssid,5,2)||':'||substr(s.bssid,7,2)||':'||substr(s.bssid,9,2)||':'||substr(s.bssid,11,2), CAST(s.ssid AS TEXT), CASE WHEN s.freq >= 5925 THEN '6 GHz' WHEN s.freq >= 5000 THEN '5 GHz' ELSE '2.4 GHz' END, s.channel, CASE WHEN s.encryption IS NULL OR s.encryption = 0 THEN 'Open' WHEN (s.encryption & 2) != 0 AND (s.encryption & 8) = 0 THEN 'WEP' WHEN ((s.encryption & 16) != 0 OR (s.encryption & 64) != 0) AND (s.encryption & 8) != 0 THEN 'WPA2/WPA3' WHEN (s.encryption & 16) != 0 OR (s.encryption & 64) != 0 THEN 'WPA3' WHEN (s.encryption & 4) != 0 AND (s.encryption & 8) != 0 THEN 'WPA/WPA2' WHEN (s.encryption & 8) != 0 THEN 'WPA2' ELSE 'Unknown' END, s.signal, w.packets, s.hidden, datetime(s.time,'unixepoch') FROM ssid s JOIN wifi_device w ON s.wifi_device=w.hash WHERE s.type=8 ORDER BY s.signal DESC LIMIT 500;" >> $CF
+
+LOG "CSV: $CF"
+
+# CLEANUP AND NOTIFY
+STOP_SPINNER $SPINNER2
+rm -f $RECON_DB_COPY
+
+LOG "Report: $RF"
+VIBRATE "alert"
+ALERT "Report ready"
+
+exit 0

--- a/library/user/reconnaissance/recondb_reporting/payload.sh
+++ b/library/user/reconnaissance/recondb_reporting/payload.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
-# Title: Recon-DB Engagement Report Generator
+# Title: Engagement Report Generator
 # Description: Queries native recon database and produces a plain-text
 #              engagement report. Uses exec stdout redirect for reliable
 #              file writing on BusyBox.
-# Author: 0xD1G5
+# Author: Digs
 # Version: 3.5
 # Type: User payload
-# Category: Reorting
 # Requires: sqlite3 (opkg install sqlite3-cli if missing)
 
 # CONFIG
@@ -29,9 +28,9 @@ if [ ! -f $RECON_DB ]; then
 fi
 
 # METADATA
-engagement="DATE_LOCATION_WIRELESS_RECON"
-target_org="Acme Corp"
-operator="UPDATE_WITH_YOUR_NAME"
+engagement="Engagement"
+target_org="Target Org"
+operator="Digs"
 
 # SETUP
 mkdir -p $REPORT_DIR
@@ -39,7 +38,7 @@ TIMESTAMP=$(date +%Y%m%d_%H%M%S)
 RF=$REPORT_DIR/report_$TIMESTAMP.txt
 GENERATED_AT=$(date +%Y-%m-%d_%H:%M:%S)
 
-SPINNER1=$(START_SPINNER "Gathering data...")
+START_SPINNER "Gathering data..."
 
 cp $RECON_DB $RECON_DB_COPY
 DB=$RECON_DB_COPY
@@ -84,8 +83,8 @@ rogue_count=0
 [ -f $ROGUE_LOG ] && rogue_count=$(grep -c ROGUE $ROGUE_LOG 2>/dev/null || echo 0)
 cred_count=$(sqlite3 $DB "SELECT count(*) FROM hostap_basic;")
 
-STOP_SPINNER $SPINNER1
-SPINNER2=$(START_SPINNER "Writing report...")
+STOP_SPINNER
+START_SPINNER "Writing report..."
 
 # REDIRECT STDOUT TO REPORT FILE
 # Save original stdout to fd 3, redirect stdout to report file.
@@ -263,21 +262,45 @@ echo "==========================================================================
 echo "  END OF REPORT -- $GENERATED_AT"
 echo "================================================================================"
 
-# CSV OUTPUT - written while stdout is still redirected to report file
-# Restore stdout first so CSV goes to its own file
+# CSV OUTPUT
+# Restore stdout before writing CSV to its own file
 exec 1>&3
 exec 3>&-
 
 CF=$REPORT_DIR/report_$TIMESTAMP.csv
 
-# AP CSV
-sqlite3 -csv $DB "SELECT 'BSSID','SSID','Band','Channel','Encryption','Signal','Packets','Hidden','Last_Seen';" > $CF
-sqlite3 -csv $DB "SELECT substr(s.bssid,1,2)||':'||substr(s.bssid,3,2)||':'||substr(s.bssid,5,2)||':'||substr(s.bssid,7,2)||':'||substr(s.bssid,9,2)||':'||substr(s.bssid,11,2), CAST(s.ssid AS TEXT), CASE WHEN s.freq >= 5925 THEN '6 GHz' WHEN s.freq >= 5000 THEN '5 GHz' ELSE '2.4 GHz' END, s.channel, CASE WHEN s.encryption IS NULL OR s.encryption = 0 THEN 'Open' WHEN (s.encryption & 2) != 0 AND (s.encryption & 8) = 0 THEN 'WEP' WHEN ((s.encryption & 16) != 0 OR (s.encryption & 64) != 0) AND (s.encryption & 8) != 0 THEN 'WPA2/WPA3' WHEN (s.encryption & 16) != 0 OR (s.encryption & 64) != 0 THEN 'WPA3' WHEN (s.encryption & 4) != 0 AND (s.encryption & 8) != 0 THEN 'WPA/WPA2' WHEN (s.encryption & 8) != 0 THEN 'WPA2' ELSE 'Unknown' END, s.signal, w.packets, s.hidden, datetime(s.time,'unixepoch') FROM ssid s JOIN wifi_device w ON s.wifi_device=w.hash WHERE s.type=8 ORDER BY s.signal DESC LIMIT 500;" >> $CF
+# Write SQL to a temp file - avoids all shell quoting issues entirely
+# The heredoc preserves quotes exactly as written with no shell interpretation
+cat > /tmp/pager_csv.sql << 'SQLEOF'
+.mode csv
+.headers on
+SELECT
+  substr(s.bssid,1,2)||':'||substr(s.bssid,3,2)||':'||substr(s.bssid,5,2)||':'||substr(s.bssid,7,2)||':'||substr(s.bssid,9,2)||':'||substr(s.bssid,11,2) AS BSSID,
+  CAST(s.ssid AS TEXT) AS SSID,
+  CASE WHEN s.freq >= 5925 THEN '6 GHz' WHEN s.freq >= 5000 THEN '5 GHz' ELSE '2.4 GHz' END AS Band,
+  s.channel AS Channel,
+  CASE WHEN s.encryption IS NULL OR s.encryption = 0 THEN 'Open'
+       WHEN (s.encryption & 2) != 0 AND (s.encryption & 8) = 0 THEN 'WEP'
+       WHEN ((s.encryption & 16) != 0 OR (s.encryption & 64) != 0) AND (s.encryption & 8) != 0 THEN 'WPA2/WPA3'
+       WHEN (s.encryption & 16) != 0 OR (s.encryption & 64) != 0 THEN 'WPA3'
+       WHEN (s.encryption & 4) != 0 AND (s.encryption & 8) != 0 THEN 'WPA/WPA2'
+       WHEN (s.encryption & 8) != 0 THEN 'WPA2'
+       ELSE 'Unknown' END AS Encryption,
+  s.signal AS Signal,
+  w.packets AS Packets,
+  s.hidden AS Hidden,
+  datetime(s.time,'unixepoch') AS Last_Seen
+FROM ssid s JOIN wifi_device w ON s.wifi_device=w.hash
+WHERE s.type=8 ORDER BY s.signal DESC LIMIT 500;
+SQLEOF
+
+sqlite3 $DB < /tmp/pager_csv.sql > $CF
+rm -f /tmp/pager_csv.sql
 
 LOG "CSV: $CF"
 
 # CLEANUP AND NOTIFY
-STOP_SPINNER $SPINNER2
+STOP_SPINNER
 rm -f $RECON_DB_COPY
 
 LOG "Report: $RF"


### PR DESCRIPTION
The Engagement Report Generator produces a formatted plain-text report and a CSV file from the Pager's native recon database at the end of a wireless reconnaissance session. No duplicate recon logic -- it reads directly from `/root/recon/recon.db`, which the PineAP engine maintains continuously in the background.