### PR TITLE
Handshake remover

### DIFF
--- a/library/user/general/Friendly_Handshake_Remover/README.md
+++ b/library/user/general/Friendly_Handshake_Remover/README.md
@@ -1,0 +1,2 @@
+This is a simple payload that removes handshakes containing a partial MAC address string or the entire MAC address, automatically converting to upper case to match the /root/loot/handshakes file schema.
+It prompts the user before deletion to confirm if the user actually wants to delete them

--- a/library/user/general/Friendly_Handshake_Remover/payload.sh
+++ b/library/user/general/Friendly_Handshake_Remover/payload.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Title: Friendly handshake deleter
+# Author: jader242
+# Description: Deletes unwanted handshakes from a target MAC
+# Version: 1.0
+
+MAC=$(TEXT_PICKER "MAC Address" "")
+
+case $? in
+    $DUCKYSCRIPT_CANCELLED)
+        LOG "User cancelled"
+        exit 1
+        ;;
+esac
+
+if [ -z "$MAC" ]; then
+        LOG "Empty MAC string"
+        exit 1
+fi
+
+UPPER_MAC=${MAC^^}
+FILES=(/root/loot/handshakes/*$UPPER_MAC*)
+COUNT=${#FILES[@]}
+
+CONFIRM=$(CONFIRMATION_DIALOG "$COUNT handshakes will be deleted containing the string $UPPER_MAC, continue?")
+
+case "$CONFIRM" in
+        $DUCKYSCRIPT_USER_CONFIRMED)
+                rm -f /root/loot/handshakes/*$UPPER_MAC*
+                LOG "Removed $COUNT handshakes containing the string $UPPER_MAC. Friendly fire will not be tolerated."
+                ;;
+        $DUCKYSCRIPT_USER_DENIED)
+                LOG "User selected no"
+                exit 1
+                ;;
+esac


### PR DESCRIPTION
Easily remove unwanted handshake files from loot, either from a partial MAC address or full. Asks user for confirmation before deletion. Helpful for those pesky times where your loot folder fills up with handshakes from networks you don't mean to target